### PR TITLE
Fix leader logic

### DIFF
--- a/src/main/kotlin/no/nav/syfo/narmesteleder/NarmesteLederController.kt
+++ b/src/main/kotlin/no/nav/syfo/narmesteleder/NarmesteLederController.kt
@@ -53,20 +53,19 @@ class NarmesteLederController @Autowired constructor(
                 .build()
         } else {
             if (!brukertilgangService.tilgangTilOppslattIdent(innloggetIdent, fnr)) {
-                LOG.error("Ikke tilgang til nærmeste ledere: Bruker spør om noen andre enn seg selv eller egne ansatte")
+                LOG.error("Ikke tilgang til nærmeste leder: Bruker spør om noen andre enn seg selv eller egne ansatte")
                 ResponseEntity
                     .status(HttpStatus.FORBIDDEN)
                     .build()
             } else {
-                val narmesteLedere = narmesteLederClient.aktivNarmesteLederIVirksomhet(
+                val aktivLeder = narmesteLederClient.aktivNarmesteLederIVirksomhet(
                     ansattFnr = fnr,
-                    narmesteLederIdent = innloggetIdent,
                     virksomhetsnummer = virksomhetsnummer
                 )
-                if (narmesteLedere != null) {
+                if (aktivLeder != null) {
                     return ResponseEntity
                         .status(HttpStatus.OK)
-                        .body(narmesteLedere.mapToNarmesteLeder())
+                        .body(aktivLeder.mapToNarmesteLeder())
                 } else {
                     return ResponseEntity
                         .status(HttpStatus.NO_CONTENT)
@@ -85,7 +84,7 @@ class NarmesteLederController @Autowired constructor(
             .fnrFromIdportenTokenX()
             .value
 
-        val narmesteLedere = narmesteLederClient.alleAktiveLedereForSykmeldt(ansattFnr = innloggetIdent)
+        val narmesteLedere = narmesteLederClient.alleLedereForSykmeldt(ansattFnr = innloggetIdent)
 
         return if (narmesteLedere.isNotEmpty()) {
             ResponseEntity

--- a/src/test/kotlin/no/nav/syfo/narmesteleder/NarmesteLederClientTest.kt
+++ b/src/test/kotlin/no/nav/syfo/narmesteleder/NarmesteLederClientTest.kt
@@ -11,7 +11,6 @@ import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.extensions.wiremock.ListenerMode
 import io.kotest.extensions.wiremock.WireMockListener
-import io.kotest.matchers.collections.shouldContainOnly
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
@@ -52,7 +51,7 @@ class NarmesteLederClientTest : FunSpec({
         every { mockJwtToken.tokenAsString } returns "heihei"
     }
 
-    test("Henter alle ledere med status INNMELDT_AKTIV") {
+    test("Henter alle ledere uavhengig av status") {
         val aktivLederIBedrift1 = createNarmestelederRelasjon(
             narmesteLederPersonIdentNumber = "123",
             virksomhetsnummer = "999",
@@ -73,10 +72,9 @@ class NarmesteLederClientTest : FunSpec({
             listOf(aktivLederIBedrift1, inaktivLederIBedrift1, aktivLederIBedrift2)
         )
 
-        val alleLedere = narmesteLederClient.alleAktiveLedereForSykmeldt(ansattFnr)
+        val alleLedere = narmesteLederClient.alleLedereForSykmeldt(ansattFnr)
 
-        alleLedere.size shouldBe 2
-        alleLedere shouldContainOnly listOf(aktivLederIBedrift1, aktivLederIBedrift2)
+        alleLedere.size shouldBe 3
     }
 
     test("aktivNarmesteLederIVirksomhet") {
@@ -100,7 +98,7 @@ class NarmesteLederClientTest : FunSpec({
             listOf(aktivLederIBedrift1, inaktivLederIBedrift1, aktivLederIBedrift2)
         )
 
-        val narmesteLederIVirksomhet = narmesteLederClient.aktivNarmesteLederIVirksomhet(ansattFnr, "123", "999")
+        val narmesteLederIVirksomhet = narmesteLederClient.aktivNarmesteLederIVirksomhet(ansattFnr, "999")
 
         narmesteLederIVirksomhet shouldBe aktivLederIBedrift1
     }


### PR DESCRIPTION
Ser ut som det ble introdusert et par bugs her. Endrer slik at det oppfører seg likt som i syfooppfolgingsplanservice:

- Hente alle ledere  for en SM uavhengig av deaktivert, aktiv osv
- Aktiv leder for virksomhet sjekker på aktivTom == null i stedet for innmeldt_aktiv status.

Testet at det funker i frontend, ber lisa teste også.