### PR TITLE
Port modia stuff

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,6 +37,7 @@ val hikariVersion = "5.1.0"
 val logstashLogbackEncoderVersion = "7.4"
 val owaspVersion = "20240325.1"
 val apacheCommonsTextVersion = "1.12.0"
+val detektVersion = "1.23.6"
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter")
@@ -74,6 +75,7 @@ dependencies {
     testImplementation("com.h2database:h2")
     testImplementation("org.wiremock:wiremock-standalone:$wiremockVersion")
     testImplementation("io.kotest.extensions:kotest-extensions-wiremock:$wiremockKotestExtensionVersion")
+    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:$detektVersion")
 }
 
 tasks.withType<KotlinCompile> {
@@ -85,4 +87,9 @@ tasks.withType<KotlinCompile> {
 
 tasks.withType<Test> {
     useJUnitPlatform()
+}
+
+detekt {
+    config.from("detekt-config.yml")
+    buildUponDefaultConfig = true
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,6 +35,8 @@ val wiremockVersion = "3.6.0"
 val wiremockKotestExtensionVersion = "3.1.0"
 val hikariVersion = "5.1.0"
 val logstashLogbackEncoderVersion = "7.4"
+val owaspVersion = "20240325.1"
+val apacheCommonsTextVersion = "1.12.0"
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter")
@@ -46,6 +48,8 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("io.micrometer:micrometer-registry-prometheus")
     implementation("org.hibernate.validator:hibernate-validator")
+    implementation("com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer:$owaspVersion")
+    implementation("org.apache.commons:commons-text:$apacheCommonsTextVersion")
     implementation("org.postgresql:postgresql")
     implementation("org.flywaydb:flyway-core")
     implementation("org.flywaydb:flyway-database-postgresql")
@@ -70,7 +74,6 @@ dependencies {
     testImplementation("com.h2database:h2")
     testImplementation("org.wiremock:wiremock-standalone:$wiremockVersion")
     testImplementation("io.kotest.extensions:kotest-extensions-wiremock:$wiremockKotestExtensionVersion")
-
 }
 
 tasks.withType<KotlinCompile> {

--- a/detekt-config.yml
+++ b/detekt-config.yml
@@ -1,0 +1,785 @@
+build:
+  maxIssues: 0
+  excludeCorrectable: false
+  weights:
+  # complexity: 2
+  # LongParameterList: 1
+  # style: 1
+  # comments: 1
+
+config:
+  validation: true
+  warningsAsErrors: false
+  checkExhaustiveness: false
+  # when writing own rules with new properties, exclude the property path e.g.: 'my_rule_set,.*>.*>[my_property]'
+  excludes: ''
+
+processors:
+  active: true
+  exclude:
+    - 'DetektProgressListener'
+  # - 'KtFileCountProcessor'
+  # - 'PackageCountProcessor'
+  # - 'ClassCountProcessor'
+  # - 'FunctionCountProcessor'
+  # - 'PropertyCountProcessor'
+  # - 'ProjectComplexityProcessor'
+  # - 'ProjectCognitiveComplexityProcessor'
+  # - 'ProjectLLOCProcessor'
+  # - 'ProjectCLOCProcessor'
+  # - 'ProjectLOCProcessor'
+  # - 'ProjectSLOCProcessor'
+  # - 'LicenseHeaderLoaderExtension'
+
+console-reports:
+  active: true
+  exclude:
+    - 'ProjectStatisticsReport'
+    - 'ComplexityReport'
+    - 'NotificationReport'
+    - 'FindingsReport'
+    - 'FileBasedFindingsReport'
+  #  - 'LiteFindingsReport'
+
+output-reports:
+  active: true
+  exclude:
+  # - 'TxtOutputReport'
+  # - 'XmlOutputReport'
+  # - 'HtmlOutputReport'
+  # - 'MdOutputReport'
+  # - 'SarifOutputReport'
+
+comments:
+  active: true
+  AbsentOrWrongFileLicense:
+    active: false
+    licenseTemplateFile: 'license.template'
+    licenseTemplateIsRegex: false
+  CommentOverPrivateFunction:
+    active: false
+  CommentOverPrivateProperty:
+    active: false
+  DeprecatedBlockTag:
+    active: false
+  EndOfSentenceFormat:
+    active: false
+    endOfSentenceFormat: '([.?!][ \t\n\r\f<])|([.?!:]$)'
+  KDocReferencesNonPublicProperty:
+    active: false
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
+  OutdatedDocumentation:
+    active: false
+    matchTypeParameters: true
+    matchDeclarationsOrder: true
+    allowParamOnConstructorProperties: false
+  UndocumentedPublicClass:
+    active: false
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
+    searchInNestedClass: true
+    searchInInnerClass: true
+    searchInInnerObject: true
+    searchInInnerInterface: true
+    searchInProtectedClass: false
+  UndocumentedPublicFunction:
+    active: false
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
+    searchProtectedFunction: false
+  UndocumentedPublicProperty:
+    active: false
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
+    searchProtectedProperty: false
+
+complexity:
+  active: true
+  CognitiveComplexMethod:
+    active: false
+    threshold: 15
+  ComplexCondition:
+    active: true
+    threshold: 4
+  ComplexInterface:
+    active: false
+    threshold: 10
+    includeStaticDeclarations: false
+    includePrivateDeclarations: false
+    ignoreOverloaded: false
+  CyclomaticComplexMethod:
+    active: true
+    threshold: 15
+    ignoreSingleWhenExpression: false
+    ignoreSimpleWhenEntries: false
+    ignoreNestingFunctions: false
+    nestingFunctions:
+      - 'also'
+      - 'apply'
+      - 'forEach'
+      - 'isNotNull'
+      - 'ifNull'
+      - 'let'
+      - 'run'
+      - 'use'
+      - 'with'
+  LabeledExpression:
+    active: false
+    ignoredLabels: []
+  LargeClass:
+    active: true
+    threshold: 600
+  LongMethod:
+    active: true
+    threshold: 60
+  LongParameterList:
+    active: true
+    functionThreshold: 6
+    constructorThreshold: 7
+    ignoreDefaultParameters: false
+    ignoreDataClasses: true
+    ignoreAnnotatedParameter: []
+  MethodOverloading:
+    active: false
+    threshold: 6
+  NamedArguments:
+    active: false
+    threshold: 3
+    ignoreArgumentsMatchingNames: false
+  NestedBlockDepth:
+    active: true
+    threshold: 4
+  NestedScopeFunctions:
+    active: false
+    threshold: 1
+    functions:
+      - 'kotlin.apply'
+      - 'kotlin.run'
+      - 'kotlin.with'
+      - 'kotlin.let'
+      - 'kotlin.also'
+  ReplaceSafeCallChainWithRun:
+    active: false
+  StringLiteralDuplication:
+    active: false
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
+    threshold: 3
+    ignoreAnnotation: true
+    excludeStringsWithLessThan5Characters: true
+    ignoreStringsRegex: '$^'
+  TooManyFunctions:
+    active: true
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
+    thresholdInFiles: 20
+    thresholdInClasses: 20
+    thresholdInInterfaces: 11
+    thresholdInObjects: 11
+    thresholdInEnums: 11
+    ignoreDeprecated: false
+    ignorePrivate: false
+    ignoreOverridden: false
+    ignoreAnnotatedFunctions: []
+
+coroutines:
+  active: true
+  GlobalCoroutineUsage:
+    active: false
+  InjectDispatcher:
+    active: true
+    dispatcherNames:
+      - 'IO'
+      - 'Default'
+      - 'Unconfined'
+  RedundantSuspendModifier:
+    active: true
+  SleepInsteadOfDelay:
+    active: true
+  SuspendFunSwallowedCancellation:
+    active: false
+  SuspendFunWithCoroutineScopeReceiver:
+    active: false
+  SuspendFunWithFlowReturnType:
+    active: true
+
+empty-blocks:
+  active: true
+  EmptyCatchBlock:
+    active: true
+    allowedExceptionNameRegex: '_|(ignore|expected).*'
+  EmptyClassBlock:
+    active: true
+  EmptyDefaultConstructor:
+    active: true
+  EmptyDoWhileBlock:
+    active: true
+  EmptyElseBlock:
+    active: true
+  EmptyFinallyBlock:
+    active: true
+  EmptyForBlock:
+    active: true
+  EmptyFunctionBlock:
+    active: true
+    ignoreOverridden: false
+  EmptyIfBlock:
+    active: true
+  EmptyInitBlock:
+    active: true
+  EmptyKtFile:
+    active: true
+  EmptySecondaryConstructor:
+    active: true
+  EmptyTryBlock:
+    active: true
+  EmptyWhenBlock:
+    active: true
+  EmptyWhileBlock:
+    active: true
+
+exceptions:
+  active: true
+  ExceptionRaisedInUnexpectedLocation:
+    active: true
+    methodNames:
+      - 'equals'
+      - 'finalize'
+      - 'hashCode'
+      - 'toString'
+  InstanceOfCheckForException:
+    active: true
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
+  NotImplementedDeclaration:
+    active: false
+  ObjectExtendsThrowable:
+    active: false
+  PrintStackTrace:
+    active: true
+  RethrowCaughtException:
+    active: true
+  ReturnFromFinally:
+    active: true
+    ignoreLabeled: false
+  SwallowedException:
+    active: true
+    ignoredExceptionTypes:
+      - 'InterruptedException'
+      - 'MalformedURLException'
+      - 'NumberFormatException'
+      - 'ParseException'
+    allowedExceptionNameRegex: '_|(ignore|expected).*'
+  ThrowingExceptionFromFinally:
+    active: true
+  ThrowingExceptionInMain:
+    active: false
+  ThrowingExceptionsWithoutMessageOrCause:
+    active: true
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
+    exceptions:
+      - 'ArrayIndexOutOfBoundsException'
+      - 'Exception'
+      - 'IllegalArgumentException'
+      - 'IllegalMonitorStateException'
+      - 'IllegalStateException'
+      - 'IndexOutOfBoundsException'
+      - 'NullPointerException'
+      - 'RuntimeException'
+      - 'Throwable'
+  ThrowingNewInstanceOfSameException:
+    active: true
+  TooGenericExceptionCaught:
+    active: true
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
+    exceptionNames:
+      - 'ArrayIndexOutOfBoundsException'
+      - 'Error'
+      - 'Exception'
+      - 'IllegalMonitorStateException'
+      - 'IndexOutOfBoundsException'
+      - 'NullPointerException'
+      - 'RuntimeException'
+      - 'Throwable'
+    allowedExceptionNameRegex: '_|(ignore|expected).*'
+  TooGenericExceptionThrown:
+    active: true
+    exceptionNames:
+      - 'Error'
+      - 'Exception'
+      - 'RuntimeException'
+      - 'Throwable'
+
+naming:
+  active: true
+  BooleanPropertyNaming:
+    active: false
+    allowedPattern: '^(is|has|are)'
+  ClassNaming:
+    active: true
+    classPattern: '[A-Z][a-zA-Z0-9]*'
+  ConstructorParameterNaming:
+    active: true
+    parameterPattern: '[a-z][A-Za-z0-9]*'
+    privateParameterPattern: '[a-z][A-Za-z0-9]*'
+    excludeClassPattern: '$^'
+  EnumNaming:
+    active: true
+    enumEntryPattern: '[A-Z][_a-zA-Z0-9]*'
+  ForbiddenClassName:
+    active: false
+    forbiddenName: []
+  FunctionMaxLength:
+    active: false
+    maximumFunctionNameLength: 30
+  FunctionMinLength:
+    active: false
+    minimumFunctionNameLength: 3
+  FunctionNaming:
+    active: true
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
+    functionPattern: '[a-z][a-zA-Z0-9]*'
+    excludeClassPattern: '$^'
+  FunctionParameterNaming:
+    active: true
+    parameterPattern: '[a-z][A-Za-z0-9]*'
+    excludeClassPattern: '$^'
+  InvalidPackageDeclaration:
+    active: true
+    rootPackage: ''
+    requireRootInDeclaration: false
+  LambdaParameterNaming:
+    active: false
+    parameterPattern: '[a-z][A-Za-z0-9]*|_'
+  MatchingDeclarationName:
+    active: true
+    mustBeFirst: true
+  MemberNameEqualsClassName:
+    active: true
+    ignoreOverridden: true
+  NoNameShadowing:
+    active: true
+  NonBooleanPropertyPrefixedWithIs:
+    active: false
+  ObjectPropertyNaming:
+    active: true
+    constantPattern: '[A-Za-z][_A-Za-z0-9]*'
+    propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
+    privatePropertyPattern: '(_)?[A-Za-z][_A-Za-z0-9]*'
+  PackageNaming:
+    active: true
+    packagePattern: '[a-z]+(\.[a-z][A-Za-z0-9]*)*'
+  TopLevelPropertyNaming:
+    active: true
+    constantPattern: '[A-Z][_A-Z0-9]*'
+    propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
+    privatePropertyPattern: '_?[A-Za-z][_A-Za-z0-9]*'
+  VariableMaxLength:
+    active: false
+    maximumVariableNameLength: 64
+  VariableMinLength:
+    active: false
+    minimumVariableNameLength: 1
+  VariableNaming:
+    active: true
+    variablePattern: '[a-z][A-Za-z0-9]*'
+    privateVariablePattern: '(_)?[a-z][A-Za-z0-9]*'
+    excludeClassPattern: '$^'
+
+performance:
+  active: true
+  ArrayPrimitive:
+    active: true
+  CouldBeSequence:
+    active: false
+    threshold: 3
+  ForEachOnRange:
+    active: true
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
+  SpreadOperator:
+    active: true
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
+  UnnecessaryPartOfBinaryExpression:
+    active: false
+  UnnecessaryTemporaryInstantiation:
+    active: true
+
+potential-bugs:
+  active: true
+  AvoidReferentialEquality:
+    active: true
+    forbiddenTypePatterns:
+      - 'kotlin.String'
+  CastNullableToNonNullableType:
+    active: false
+  CastToNullableType:
+    active: false
+  Deprecation:
+    active: false
+  DontDowncastCollectionTypes:
+    active: false
+  DoubleMutabilityForCollection:
+    active: true
+    mutableTypes:
+      - 'kotlin.collections.MutableList'
+      - 'kotlin.collections.MutableMap'
+      - 'kotlin.collections.MutableSet'
+      - 'java.util.ArrayList'
+      - 'java.util.LinkedHashSet'
+      - 'java.util.HashSet'
+      - 'java.util.LinkedHashMap'
+      - 'java.util.HashMap'
+  ElseCaseInsteadOfExhaustiveWhen:
+    active: false
+    ignoredSubjectTypes: []
+  EqualsAlwaysReturnsTrueOrFalse:
+    active: true
+  EqualsWithHashCodeExist:
+    active: true
+  ExitOutsideMain:
+    active: false
+  ExplicitGarbageCollectionCall:
+    active: true
+  HasPlatformType:
+    active: true
+  IgnoredReturnValue:
+    active: true
+    restrictToConfig: true
+    returnValueAnnotations:
+      - 'CheckResult'
+      - '*.CheckResult'
+      - 'CheckReturnValue'
+      - '*.CheckReturnValue'
+    ignoreReturnValueAnnotations:
+      - 'CanIgnoreReturnValue'
+      - '*.CanIgnoreReturnValue'
+    returnValueTypes:
+      - 'kotlin.sequences.Sequence'
+      - 'kotlinx.coroutines.flow.*Flow'
+      - 'java.util.stream.*Stream'
+    ignoreFunctionCall: []
+  ImplicitDefaultLocale:
+    active: true
+  ImplicitUnitReturnType:
+    active: false
+    allowExplicitReturnType: true
+  InvalidRange:
+    active: true
+  IteratorHasNextCallsNextMethod:
+    active: true
+  IteratorNotThrowingNoSuchElementException:
+    active: true
+  LateinitUsage:
+    active: false
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
+    ignoreOnClassesPattern: ''
+  MapGetWithNotNullAssertionOperator:
+    active: true
+  MissingPackageDeclaration:
+    active: false
+    excludes: ['**/*.kts']
+  NullCheckOnMutableProperty:
+    active: false
+  NullableToStringCall:
+    active: false
+  PropertyUsedBeforeDeclaration:
+    active: false
+  UnconditionalJumpStatementInLoop:
+    active: false
+  UnnecessaryNotNullCheck:
+    active: false
+  UnnecessaryNotNullOperator:
+    active: true
+  UnnecessarySafeCall:
+    active: true
+  UnreachableCatchBlock:
+    active: true
+  UnreachableCode:
+    active: true
+  UnsafeCallOnNullableType:
+    active: true
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
+  UnsafeCast:
+    active: true
+  UnusedUnaryOperator:
+    active: true
+  UselessPostfixExpression:
+    active: true
+  WrongEqualsTypeParameter:
+    active: true
+
+style:
+  active: true
+  AlsoCouldBeApply:
+    active: false
+  BracesOnIfStatements:
+    active: false
+    singleLine: 'never'
+    multiLine: 'always'
+  BracesOnWhenStatements:
+    active: false
+    singleLine: 'necessary'
+    multiLine: 'consistent'
+  CanBeNonNullable:
+    active: false
+  CascadingCallWrapping:
+    active: false
+    includeElvis: true
+  ClassOrdering:
+    active: false
+  CollapsibleIfStatements:
+    active: false
+  DataClassContainsFunctions:
+    active: false
+    conversionFunctionPrefix:
+      - 'to'
+    allowOperators: false
+  DataClassShouldBeImmutable:
+    active: false
+  DestructuringDeclarationWithTooManyEntries:
+    active: true
+    maxDestructuringEntries: 3
+  DoubleNegativeLambda:
+    active: false
+    negativeFunctions:
+      - reason: 'Use `takeIf` instead.'
+        value: 'takeUnless'
+      - reason: 'Use `all` instead.'
+        value: 'none'
+    negativeFunctionNameParts:
+      - 'not'
+      - 'non'
+  EqualsNullCall:
+    active: true
+  EqualsOnSignatureLine:
+    active: false
+  ExplicitCollectionElementAccessMethod:
+    active: false
+  ExplicitItLambdaParameter:
+    active: true
+  ExpressionBodySyntax:
+    active: false
+    includeLineWrapping: false
+  ForbiddenAnnotation:
+    active: false
+    annotations:
+      - reason: 'it is a java annotation. Use `Suppress` instead.'
+        value: 'java.lang.SuppressWarnings'
+      - reason: 'it is a java annotation. Use `kotlin.Deprecated` instead.'
+        value: 'java.lang.Deprecated'
+      - reason: 'it is a java annotation. Use `kotlin.annotation.MustBeDocumented` instead.'
+        value: 'java.lang.annotation.Documented'
+      - reason: 'it is a java annotation. Use `kotlin.annotation.Target` instead.'
+        value: 'java.lang.annotation.Target'
+      - reason: 'it is a java annotation. Use `kotlin.annotation.Retention` instead.'
+        value: 'java.lang.annotation.Retention'
+      - reason: 'it is a java annotation. Use `kotlin.annotation.Repeatable` instead.'
+        value: 'java.lang.annotation.Repeatable'
+      - reason: 'Kotlin does not support @Inherited annotation, see https://youtrack.jetbrains.com/issue/KT-22265'
+        value: 'java.lang.annotation.Inherited'
+  ForbiddenComment:
+    active: true
+    comments:
+      - reason: 'Forbidden FIXME todo marker in comment, please fix the problem.'
+        value: 'FIXME:'
+      - reason: 'Forbidden STOPSHIP todo marker in comment, please address the problem before shipping the code.'
+        value: 'STOPSHIP:'
+      - reason: 'Forbidden TODO todo marker in comment, please do the changes.'
+        value: 'TODO:'
+    allowedPatterns: ''
+  ForbiddenImport:
+    active: false
+    imports: []
+    forbiddenPatterns: ''
+  ForbiddenMethodCall:
+    active: false
+    methods:
+      - reason: 'print does not allow you to configure the output stream. Use a logger instead.'
+        value: 'kotlin.io.print'
+      - reason: 'println does not allow you to configure the output stream. Use a logger instead.'
+        value: 'kotlin.io.println'
+  ForbiddenSuppress:
+    active: false
+    rules: []
+  ForbiddenVoid:
+    active: true
+    ignoreOverridden: false
+    ignoreUsageInGenerics: false
+  FunctionOnlyReturningConstant:
+    active: true
+    ignoreOverridableFunction: true
+    ignoreActualFunction: true
+    excludedFunctions: []
+  LoopWithTooManyJumpStatements:
+    active: true
+    maxJumpCount: 1
+  MagicNumber:
+    active: false
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**', '**/*.kts']
+    ignoreNumbers:
+      - '-1'
+      - '0'
+      - '1'
+      - '2'
+    ignoreHashCodeFunction: true
+    ignorePropertyDeclaration: false
+    ignoreLocalVariableDeclaration: false
+    ignoreConstantDeclaration: true
+    ignoreCompanionObjectPropertyDeclaration: true
+    ignoreAnnotation: false
+    ignoreNamedArgument: true
+    ignoreEnums: false
+    ignoreRanges: false
+    ignoreExtensionFunctions: true
+  MandatoryBracesLoops:
+    active: false
+  MaxChainedCallsOnSameLine:
+    active: false
+    maxChainedCalls: 5
+  MaxLineLength:
+    active: true
+    maxLineLength: 120
+    excludePackageStatements: true
+    excludeImportStatements: true
+    excludeCommentStatements: false
+    excludeRawStrings: true
+  MayBeConst:
+    active: true
+  ModifierOrder:
+    active: true
+  MultilineLambdaItParameter:
+    active: false
+  MultilineRawStringIndentation:
+    active: false
+    indentSize: 4
+    trimmingMethods:
+      - 'trimIndent'
+      - 'trimMargin'
+  NestedClassesVisibility:
+    active: true
+  NewLineAtEndOfFile:
+    active: true
+  NoTabs:
+    active: false
+  NullableBooleanCheck:
+    active: false
+  ObjectLiteralToLambda:
+    active: true
+  OptionalAbstractKeyword:
+    active: true
+  OptionalUnit:
+    active: false
+  PreferToOverPairSyntax:
+    active: false
+  ProtectedMemberInFinalClass:
+    active: true
+  RedundantExplicitType:
+    active: false
+  RedundantHigherOrderMapUsage:
+    active: true
+  RedundantVisibilityModifierRule:
+    active: false
+  ReturnCount:
+    active: true
+    max: 2
+    excludedFunctions:
+      - 'equals'
+    excludeLabeled: false
+    excludeReturnFromLambda: true
+    excludeGuardClauses: false
+  SafeCast:
+    active: true
+  SerialVersionUIDInSerializableClass:
+    active: true
+  SpacingBetweenPackageAndImports:
+    active: false
+  StringShouldBeRawString:
+    active: false
+    maxEscapedCharacterCount: 2
+    ignoredCharacters: []
+  ThrowsCount:
+    active: true
+    max: 2
+    excludeGuardClauses: false
+  TrailingWhitespace:
+    active: false
+  TrimMultilineRawString:
+    active: false
+    trimmingMethods:
+      - 'trimIndent'
+      - 'trimMargin'
+  UnderscoresInNumericLiterals:
+    active: false
+    acceptableLength: 4
+    allowNonStandardGrouping: false
+  UnnecessaryAbstractClass:
+    active: true
+  UnnecessaryAnnotationUseSiteTarget:
+    active: false
+  UnnecessaryApply:
+    active: true
+  UnnecessaryBackticks:
+    active: false
+  UnnecessaryBracesAroundTrailingLambda:
+    active: false
+  UnnecessaryFilter:
+    active: true
+  UnnecessaryInheritance:
+    active: true
+  UnnecessaryInnerClass:
+    active: false
+  UnnecessaryLet:
+    active: false
+  UnnecessaryParentheses:
+    active: false
+    allowForUnclearPrecedence: false
+  UntilInsteadOfRangeTo:
+    active: false
+  UnusedImports:
+    active: false
+  UnusedParameter:
+    active: true
+    allowedNames: 'ignored|expected'
+  UnusedPrivateClass:
+    active: true
+  UnusedPrivateMember:
+    active: true
+    allowedNames: ''
+  UnusedPrivateProperty:
+    active: true
+    allowedNames: '_|ignored|expected|serialVersionUID'
+  UseAnyOrNoneInsteadOfFind:
+    active: true
+  UseArrayLiteralsInAnnotations:
+    active: true
+  UseCheckNotNull:
+    active: true
+  UseCheckOrError:
+    active: true
+  UseDataClass:
+    active: false
+    allowVars: false
+  UseEmptyCounterpart:
+    active: false
+  UseIfEmptyOrIfBlank:
+    active: false
+  UseIfInsteadOfWhen:
+    active: false
+    ignoreWhenContainingVariableDeclaration: false
+  UseIsNullOrEmpty:
+    active: true
+  UseLet:
+    active: false
+  UseOrEmpty:
+    active: true
+  UseRequire:
+    active: true
+  UseRequireNotNull:
+    active: true
+  UseSumOfInsteadOfFlatMapSize:
+    active: false
+  UselessCallOnNotNull:
+    active: true
+  UtilityClassWithPublicConstructor:
+    active: true
+  VarCouldBeVal:
+    active: true
+    ignoreLateinitVar: false
+  WildcardImport:
+    active: true
+    excludeImports:
+      - 'java.util.*'

--- a/nais/nais-dev.yaml
+++ b/nais/nais-dev.yaml
@@ -60,6 +60,9 @@ spec:
         - application: isnarmesteleder
           namespace: teamsykefravr
           cluster: dev-gcp
+        - application: istilgangskontroll
+          namespace: teamsykefravr
+          cluster: dev-gcp
   azure:
     application:
       allowAllUsers: true
@@ -112,6 +115,10 @@ spec:
       value: "https://pdl-api.dev-fss-pub.nais.io/graphql"
     - name: EREG_URL
       value: https://ereg-services-q1.dev-fss-pub.nais.io
+    - name: ISTILGANGSKONTROLL_CLIENT_ID
+      value: dev-gcp.teamsykefravr.istilgangskontroll
+    - name: ISTILGANGSKONTROLL_URL
+      value: http://istilgangskontroll.teamsykefravr
   redis:
     - instance: oppfolgingsplan
       access: readwrite

--- a/nais/nais-prod.yaml
+++ b/nais/nais-prod.yaml
@@ -60,6 +60,9 @@ spec:
         - application: isnarmesteleder
           namespace: teamsykefravr
           cluster: prod-gcp
+        - application: istilgangskontroll
+          namespace: teamsykefravr
+          cluster: prod-gcp
   azure:
     application:
       allowAllUsers: true
@@ -112,6 +115,10 @@ spec:
       value: "https://pdl-api.prod-fss-pub.nais.io/graphql"
     - name: EREG_URL
       value: https://ereg-services.prod-fss-pub.nais.io
+    - name: ISTILGANGSKONTROLL_CLIENT_ID
+      value: prod-gcp.teamsykefravr.istilgangskontroll
+    - name: ISTILGANGSKONTROLL_URL
+      value: http://istilgangskontroll.teamsykefravr
   redis:
     - instance: oppfolgingsplan
       access: readwrite

--- a/src/main/kotlin/no/nav/syfo/brukertilgang/BrukertilgangService.kt
+++ b/src/main/kotlin/no/nav/syfo/brukertilgang/BrukertilgangService.kt
@@ -17,4 +17,3 @@ class BrukertilgangService @Autowired constructor(
         return oppslaattFnr == innloggetIdent || brukertilgangClient.hasAccessToAnsatt(oppslaattFnr)
     }
 }
-

--- a/src/main/kotlin/no/nav/syfo/config/RedisConfig.kt
+++ b/src/main/kotlin/no/nav/syfo/config/RedisConfig.kt
@@ -9,7 +9,6 @@ import org.springframework.data.redis.connection.lettuce.LettuceClientConfigurat
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
 import java.net.URI
 
-
 @Configuration
 class RedisConfig {
     @Bean
@@ -24,7 +23,8 @@ class RedisConfig {
                 setUsername(username)
                 setPassword(password)
                 database = redisURI.database
-            }, LettuceClientConfiguration.builder().apply {
+            },
+            LettuceClientConfiguration.builder().apply {
                 if (redisURI.isSsl) {
                     useSsl()
                 }

--- a/src/main/kotlin/no/nav/syfo/ereg/EregClient.kt
+++ b/src/main/kotlin/no/nav/syfo/ereg/EregClient.kt
@@ -17,7 +17,7 @@ import org.springframework.web.client.RestClientResponseException
 import org.springframework.web.client.RestTemplate
 
 @Service
-class EregClient (
+class EregClient(
     @Value("\${ereg.url}") private val baseUrl: String,
     private val metric: Metrikk,
 ) {
@@ -37,11 +37,12 @@ class EregClient (
             metric.tellHendelse(METRIC_CALL_EREG_FAIL)
             val message =
                 "Call to get name Virksomhetsnummer from EREG failed with status:" +
-                        " ${e.statusCode.value()} and message: ${e.responseBodyAsString}"
+                    " ${e.statusCode.value()} and message: ${e.responseBodyAsString}"
             LOG.error(message)
             throw e
         }
     }
+
     @Cacheable(
         value = ["ereg_virksomhetsnavn"],
         key = "#virksomhetsnummer",

--- a/src/main/kotlin/no/nav/syfo/ereg/EregOrganisasjonResponse.kt
+++ b/src/main/kotlin/no/nav/syfo/ereg/EregOrganisasjonResponse.kt
@@ -4,13 +4,13 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class EregOrganisasjonResponse(
-        val navn: EregOrganisasjonNavn
+    val navn: EregOrganisasjonNavn
 )
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class EregOrganisasjonNavn(
-        val navnelinje1: String,
-        val sammensattnavn: String?
+    val navnelinje1: String,
+    val sammensattnavn: String?
 )
 
 fun EregOrganisasjonResponse.navn(): String {

--- a/src/main/kotlin/no/nav/syfo/exception/NameNotFoundException.kt
+++ b/src/main/kotlin/no/nav/syfo/exception/NameNotFoundException.kt
@@ -1,0 +1,3 @@
+package no.nav.syfo.exception
+
+class NameNotFoundException(message: String) : Exception(message)

--- a/src/main/kotlin/no/nav/syfo/exception/OppfolgingsplanNotFoundException.kt
+++ b/src/main/kotlin/no/nav/syfo/exception/OppfolgingsplanNotFoundException.kt
@@ -1,0 +1,3 @@
+package no.nav.syfo.exception
+
+class OppfolgingsplanNotFoundException(message: String) : Exception(message)

--- a/src/main/kotlin/no/nav/syfo/exception/TiltakNotFoundException.kt
+++ b/src/main/kotlin/no/nav/syfo/exception/TiltakNotFoundException.kt
@@ -1,0 +1,3 @@
+package no.nav.syfo.exception
+
+class TiltakNotFoundException(message: String) : Exception(message)

--- a/src/main/kotlin/no/nav/syfo/kontaktinfo/KontaktinfoController.kt
+++ b/src/main/kotlin/no/nav/syfo/kontaktinfo/KontaktinfoController.kt
@@ -2,10 +2,10 @@ package no.nav.syfo.kontaktinfo
 
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import no.nav.security.token.support.core.context.TokenValidationContextHolder
-import no.nav.syfo.brukertilgang.BrukertilgangService
 import no.nav.syfo.auth.tokenx.TokenXUtil
 import no.nav.syfo.auth.tokenx.TokenXUtil.TokenXIssuer.TOKENX
 import no.nav.syfo.auth.tokenx.TokenXUtil.fnrFromIdportenTokenX
+import no.nav.syfo.brukertilgang.BrukertilgangService
 import no.nav.syfo.util.NAV_PERSONIDENT_HEADER
 import no.nav.syfo.util.fodselsnummerInvalid
 import org.slf4j.LoggerFactory

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/domain/Historikk.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/domain/Historikk.kt
@@ -1,0 +1,9 @@
+package no.nav.syfo.oppfolgingsplan.domain
+
+import java.time.LocalDateTime
+
+data class Historikk(
+    val opprettetAv: String? = null,
+    val tekst: String? = null,
+    val tidspunkt: LocalDateTime? = null
+)

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/domain/OppfolgingsplanDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/domain/OppfolgingsplanDTO.kt
@@ -1,0 +1,152 @@
+package no.nav.syfo.oppfolgingsplan.domain
+
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+data class OppfolgingsplanDTO(
+    val id: Long,
+    val uuid: String,
+    val opprettet: LocalDateTime,
+    val sistEndretAvAktoerId: String?,
+    val sistEndretAvFnr: String?,
+    val opprettetAvAktoerId: String?,
+    val opprettetAvFnr: String?,
+    val sistEndretDato: LocalDateTime?,
+    val sistEndretArbeidsgiver: LocalDateTime?,
+    val sistEndretSykmeldt: LocalDateTime?,
+    val status: String?,
+    val virksomhet: VirksomhetDTO,
+    val godkjentPlan: GodkjentPlanDTO?,
+    val godkjenninger: List<GodkjenningDTO>,
+    val arbeidsoppgaveListe: List<ArbeidsoppgaveDTO>,
+    val tiltakListe: List<TiltakDTO>,
+    val arbeidsgiver: PersonDTO,
+    val arbeidstaker: PersonDTO
+)
+
+data class VirksomhetDTO(
+    val navn: String?,
+    val virksomhetsnummer: String
+)
+
+data class GodkjentPlanDTO(
+    val id: Long,
+    val oppfoelgingsdialogId: Long,
+    val opprettetTidspunkt: LocalDateTime,
+    val gyldighetstidspunkt: GyldighetstidspunktDTO,
+    val tvungenGodkjenning: Boolean,
+    val deltMedNAVTidspunkt: LocalDateTime?,
+    val deltMedNAV: Boolean,
+    val deltMedFastlege: Boolean,
+    val deltMedFastlegeTidspunkt: LocalDateTime?,
+    val dokumentUuid: String?,
+    val avbruttPlan: AvbruttplanDTO?,
+    val sakId: String?,
+    val journalpostId: String?,
+    val tildeltEnhet: String?,
+    val dokument: ByteArray?
+)
+
+data class GyldighetstidspunktDTO(
+    val fom: LocalDate?,
+    val tom: LocalDate?,
+    val evalueres: LocalDate?
+)
+
+data class AvbruttplanDTO(
+    val avAktoerId: String?,
+    val tidspunkt: LocalDateTime?,
+    val oppfoelgingsdialogId: Long?
+)
+
+data class GodkjenningDTO(
+    val id: Long,
+    val oppfoelgingsdialogId: Long,
+    val godkjent: Boolean,
+    val delMedNav: Boolean,
+    val godkjentAvAktoerId: String?,
+    val beskrivelse: String?,
+    val godkjenningsTidspunkt: LocalDateTime?,
+    val gyldighetstidspunkt: GyldighetstidspunktDTO?
+)
+
+data class ArbeidsoppgaveDTO(
+    val id: Long,
+    val oppfoelgingsdialogId: Long,
+    val navn: String?,
+    val erVurdertAvSykmeldt: Boolean,
+    val gjennomfoering: GjennomfoeringDTO?,
+    val sistEndretAvAktoerId: String?,
+    val sistEndretDato: LocalDateTime?,
+    val opprettetAvAktoerId: String?,
+    val opprettetDato: LocalDateTime
+)
+
+data class GjennomfoeringDTO(
+    val gjennomfoeringStatus: KanGjennomfoeres?,
+    val paaAnnetSted: Boolean?,
+    val medMerTid: Boolean?,
+    val medHjelp: Boolean?,
+    val kanBeskrivelse: String?,
+    val kanIkkeBeskrivelse: String?,
+) {
+    enum class KanGjennomfoeres {
+        KAN,
+        KAN_IKKE,
+        TILRETTELEGGING
+    }
+}
+
+data class TiltakDTO(
+    val id: Long,
+    val oppfoelgingsdialogId: Long,
+    val navn: String?,
+    val fom: LocalDate?,
+    val tom: LocalDate?,
+    val beskrivelse: String?,
+    val status: String?,
+    val gjennomfoering: String?,
+    val beskrivelseIkkeAktuelt: String?,
+    val kommentarer: List<KommentarDTO>?,
+    val opprettetDato: LocalDateTime?,
+    val sistEndretDato: LocalDateTime?,
+    val opprettetAvAktoerId: String?,
+    val sistEndretAvAktoerId: String?
+)
+
+data class KommentarDTO(
+    val id: Long,
+    val tiltakId: Long,
+    val tekst: String?,
+    val sistEndretAvAktoerId: String?,
+    val sistEndretDato: LocalDateTime?,
+    val opprettetAvAktoerId: String?,
+    val opprettetDato: LocalDateTime?
+)
+
+data class PersonDTO(
+    val navn: String?,
+    val aktoerId: String?,
+    val fnr: String?,
+    val epost: String?,
+    val tlf: String?,
+    val sistInnlogget: LocalDateTime?,
+    val sisteEndring: LocalDateTime?,
+    val sistAksessert: LocalDateTime?,
+    val samtykke: Boolean?
+)
+
+fun OppfolgingsplanDTO.getStatus(): Status {
+    return when {
+        godkjentPlan?.avbruttPlan != null -> Status.AVBRUTT
+        godkjentPlan?.gyldighetstidspunkt?.tom?.isBefore(LocalDate.now()) == true -> Status.UTDATERT
+        godkjentPlan != null -> Status.AKTIV
+        else -> Status.UNDER_ARBEID
+    }
+}
+enum class Status {
+    AVBRUTT,
+    UTDATERT,
+    AKTIV,
+    UNDER_ARBEID
+}

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/domain/rs/RSGodkjentPlan.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/domain/rs/RSGodkjentPlan.kt
@@ -1,0 +1,14 @@
+package no.nav.syfo.oppfolgingsplan.domain.rs
+
+import java.time.LocalDateTime
+
+data class RSGodkjentPlan(
+    var opprettetTidspunkt: LocalDateTime? = null,
+    var gyldighetstidspunkt: RSGyldighetstidspunkt? = null,
+    var tvungenGodkjenning: Boolean = false,
+    var deltMedNAVTidspunkt: LocalDateTime? = null,
+    var deltMedNAV: Boolean = false,
+    var deltMedFastlegeTidspunkt: LocalDateTime? = null,
+    var deltMedFastlege: Boolean = false,
+    var dokumentUuid: String? = null
+)

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/domain/rs/RSGyldighetstidspunkt.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/domain/rs/RSGyldighetstidspunkt.kt
@@ -1,0 +1,9 @@
+package no.nav.syfo.oppfolgingsplan.domain.rs
+
+import java.time.LocalDate
+
+data class RSGyldighetstidspunkt(
+    var fom: LocalDate? = null,
+    var tom: LocalDate? = null,
+    var evalueres: LocalDate? = null
+)

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/domain/rs/RSOppfoelgingsdialog.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/domain/rs/RSOppfoelgingsdialog.kt
@@ -1,0 +1,19 @@
+package no.nav.syfo.oppfolgingsplan.domain.rs
+
+import java.time.LocalDateTime
+
+data class RSOppfoelgingsdialog(
+    var id: Long? = null,
+    var uuid: String? = null,
+
+    var sistEndretAvAktoerId: String? = null,
+    var sistEndretDato: LocalDateTime? = null,
+
+    var status: String? = null,
+    var virksomhet: RSVirksomhet? = null,
+
+    var godkjentPlan: RSGodkjentPlan? = null,
+
+    var arbeidsgiver: RSPerson? = null,
+    var arbeidstaker: RSPerson? = null
+)

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/domain/rs/RSPerson.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/domain/rs/RSPerson.kt
@@ -1,0 +1,13 @@
+package no.nav.syfo.oppfolgingsplan.domain.rs
+
+import java.time.LocalDateTime
+
+data class RSPerson(
+    var navn: String? = null,
+    var aktoerId: String? = null,
+    var fnr: String? = null,
+    var epost: String? = null,
+    var tlf: String? = null,
+    var sistInnlogget: LocalDateTime? = null,
+    var samtykke: Boolean? = null
+)

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/domain/rs/RSVirksomhet.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/domain/rs/RSVirksomhet.kt
@@ -1,0 +1,6 @@
+package no.nav.syfo.oppfolgingsplan.domain.rs
+
+data class RSVirksomhet(
+    var navn: String? = null,
+    var virksomhetsnummer: String? = null
+)

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/internal/v1/OppfolgingsplanInternControllerV1.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/internal/v1/OppfolgingsplanInternControllerV1.kt
@@ -1,0 +1,71 @@
+package no.nav.syfo.oppfolgingsplan.internal.v1
+
+import no.nav.security.token.support.core.api.ProtectedWithClaims
+import no.nav.syfo.auth.oidc.OIDCIssuer.INTERN_AZUREAD_V2
+import no.nav.syfo.domain.Fodselsnummer
+import no.nav.syfo.ereg.EregClient
+import no.nav.syfo.exception.NameNotFoundException
+import no.nav.syfo.oppfolgingsplan.domain.Historikk
+import no.nav.syfo.oppfolgingsplan.domain.OppfolgingsplanDTO
+import no.nav.syfo.oppfolgingsplan.domain.rs.RSOppfoelgingsdialog
+import no.nav.syfo.oppfolgingsplan.mapper.oppfoelgingsdialog2rs
+import no.nav.syfo.oppfolgingsplan.repository.dao.OppfolgingsplanDAO
+import no.nav.syfo.pdl.PdlClient
+import no.nav.syfo.pdl.fullName
+import no.nav.syfo.util.NAV_PERSONIDENT_HEADER
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@ProtectedWithClaims(issuer = INTERN_AZUREAD_V2)
+@RequestMapping(value = ["/api/internad/v1/oppfolgingsplan"])
+class OppfolgingsplanInternControllerV1(
+    private val pdlClient: PdlClient,
+    private val eregClient: EregClient,
+    private val oppfolgingsplanDAO: OppfolgingsplanDAO,
+    private val veilederTilgangClient: VeilederTilgangClient
+) {
+    private fun finnDeltAvNavn(oppfolgingsplan: OppfolgingsplanDTO): String {
+        val arbeidstakersAktoerId = oppfolgingsplan.arbeidstaker.aktoerId
+        if (oppfolgingsplan.sistEndretAvAktoerId == arbeidstakersAktoerId) {
+            return pdlClient.person(arbeidstakersAktoerId!!)?.fullName()
+                ?: throw NameNotFoundException("Name from PDL not found")
+        }
+        return eregClient.virksomhetsnavn(oppfolgingsplan.virksomhet.virksomhetsnummer)
+    }
+
+    @GetMapping(produces = [MediaType.APPLICATION_JSON_VALUE])
+    @RequestMapping(value = ["/historikk"])
+    fun getHistorikk(@RequestHeader(name = NAV_PERSONIDENT_HEADER) personident: String): List<Historikk> {
+        val personFnr = Fodselsnummer(personident)
+
+        veilederTilgangClient.throwExceptionIfVeilederWithoutAccessWithOBO(personFnr)
+
+        val godkjentePlanerSomErDeltMedNAV = oppfolgingsplanDAO.oppfolgingsplanerKnyttetTilSykmeldt(personFnr.value)
+            .mapNotNull { oppfolgingsplanDAO.populate(it).takeIf { plan -> plan.godkjentPlan?.deltMedNAV == true } }
+
+        return godkjentePlanerSomErDeltMedNAV.map {
+            Historikk(
+                tekst = "Oppfølgingsplanen ble delt med NAV av ${finnDeltAvNavn(it)}.",
+                tidspunkt = it.godkjentPlan?.deltMedNAVTidspunkt
+            )
+        }
+    }
+
+    @GetMapping(produces = [MediaType.APPLICATION_JSON_VALUE])
+    fun getOppfolgingsplaner(
+        @RequestHeader(name = NAV_PERSONIDENT_HEADER) personident: String
+    ): List<RSOppfoelgingsdialog> {
+        val personFnr = Fodselsnummer(personident)
+
+        veilederTilgangClient.throwExceptionIfVeilederWithoutAccessWithOBO(personFnr)
+
+        val godkjentePlanerSomErDeltMedNAV = oppfolgingsplanDAO.oppfolgingsplanerKnyttetTilSykmeldt(personFnr.value)
+            .mapNotNull { oppfolgingsplanDAO.populate(it).takeIf { plan -> plan.godkjentPlan?.deltMedNAV == true } }
+
+        return godkjentePlanerSomErDeltMedNAV.map { oppfoelgingsdialog2rs(it) }
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/internal/v1/VeilederTilgangClient.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/internal/v1/VeilederTilgangClient.kt
@@ -1,0 +1,141 @@
+package no.nav.syfo.oppfolgingsplan.internal.v1
+
+import no.nav.security.token.support.core.context.TokenValidationContextHolder
+import no.nav.syfo.auth.azure.AzureAdTokenClient
+import no.nav.syfo.auth.oidc.OIDCIssuer
+import no.nav.syfo.auth.oidc.TokenUtil.getIssuerToken
+import no.nav.syfo.domain.Fodselsnummer
+import no.nav.syfo.metric.Metrikk
+import no.nav.syfo.util.APP_CONSUMER_ID
+import no.nav.syfo.util.NAV_CALL_ID_HEADER
+import no.nav.syfo.util.NAV_CONSUMER_ID_HEADER
+import no.nav.syfo.util.NAV_PERSONIDENT_HEADER
+import no.nav.syfo.util.createCallId
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Service
+import org.springframework.web.client.HttpClientErrorException
+import org.springframework.web.client.RestTemplate
+import org.springframework.web.server.ResponseStatusException
+
+@Service
+class VeilederTilgangClient(
+    @Value("\${istilgangskontroll.client.id}") private val istilgangskontrollClientId: String,
+    @Value("\${istilgangskontroll.url}") private val istilgangskontrollUrl: String,
+    private val azureAdTokenClient: AzureAdTokenClient,
+    private val metric: Metrikk,
+    private val contextHolder: TokenValidationContextHolder,
+) {
+    private val tilgangskontrollPersonUrl = "$istilgangskontrollUrl$TILGANGSKONTROLL_PERSON_PATH"
+    private val tilgangskontrollPersonSYFOUrl = "$istilgangskontrollUrl$TILGANGSKONTROLL_SYFO_PATH"
+
+    fun throwExceptionIfVeilederWithoutAccessWithOBO(fnr: Fodselsnummer) {
+        val harTilgang = hasVeilederAccessToPersonWithOBO(fnr)
+        if (!harTilgang) {
+            throw ResponseStatusException(HttpStatus.FORBIDDEN, "Access Denied")
+        }
+    }
+
+    private fun hasVeilederAccessToPersonWithOBO(fnr: Fodselsnummer): Boolean {
+        val oboToken = azureAdTokenClient.getOnBehalfOfToken(
+            scopeClientId = istilgangskontrollClientId,
+            token = getIssuerToken(contextHolder, OIDCIssuer.INTERN_AZUREAD_V2),
+        )
+        val httpEntity = entityPerson(
+            personIdentNumber = fnr,
+            token = oboToken,
+        )
+        return checkAccess(
+            httpEntity = httpEntity,
+            url = tilgangskontrollPersonUrl,
+        )
+    }
+
+    fun throwExceptionIfVeilederWithoutAccessToSYFOWithOBO() {
+        val harTilgang = hasVeilederAccessToSYFOWithOBO()
+        if (!harTilgang) {
+            throw ResponseStatusException(HttpStatus.FORBIDDEN, "Access Denied")
+        }
+    }
+
+    private fun hasVeilederAccessToSYFOWithOBO(): Boolean {
+        val oboToken = azureAdTokenClient.getOnBehalfOfToken(
+            scopeClientId = istilgangskontrollClientId,
+            token = getIssuerToken(contextHolder, OIDCIssuer.INTERN_AZUREAD_V2),
+        )
+        val httpEntity = entitySYFO(token = oboToken)
+        return checkAccess(
+            httpEntity = httpEntity,
+            url = tilgangskontrollPersonSYFOUrl,
+        )
+    }
+
+    private fun entityPerson(
+        personIdentNumber: Fodselsnummer,
+        token: String,
+    ): HttpEntity<String> {
+        val headers = HttpHeaders()
+        headers.accept = listOf(MediaType.APPLICATION_JSON)
+        headers.setBearerAuth(token)
+        headers[NAV_PERSONIDENT_HEADER] = personIdentNumber.value
+        headers[NAV_CALL_ID_HEADER] = createCallId()
+        headers[NAV_CONSUMER_ID_HEADER] = APP_CONSUMER_ID
+        return HttpEntity(headers)
+    }
+
+    private fun entitySYFO(token: String): HttpEntity<String> {
+        val headers = HttpHeaders()
+        headers.accept = listOf(MediaType.APPLICATION_JSON)
+        headers.setBearerAuth(token)
+        headers[NAV_CALL_ID_HEADER] = createCallId()
+        headers[NAV_CONSUMER_ID_HEADER] = APP_CONSUMER_ID
+        return HttpEntity(headers)
+    }
+
+    private fun checkAccess(
+        httpEntity: HttpEntity<String>,
+        url: String,
+    ): Boolean {
+        return try {
+            val tilgang = RestTemplate().exchange(
+                url,
+                HttpMethod.GET,
+                httpEntity,
+                Tilgang::class.java,
+            )
+            tilgang.body!!.erGodkjent
+        } catch (e: HttpClientErrorException) {
+            if (e.statusCode.value() == HttpStatus.FORBIDDEN.value()) {
+                false
+            } else {
+                metric.tellHendelse(METRIC_CALL_VEILEDERTILGANG_USER_FAIL)
+                LOG.error(
+                    "Error requesting ansatt access from istilgangskontroll with status-${e.statusCode.value()} " +
+                        "callId-${httpEntity.headers[NAV_CALL_ID_HEADER]}: ",
+                    e
+                )
+                throw e
+            }
+        }
+    }
+
+    companion object {
+        private val LOG = LoggerFactory.getLogger(VeilederTilgangClient::class.java)
+
+        private const val METRIC_CALL_VEILEDERTILGANG_BASE = "call_istilgangskontroll"
+        private const val METRIC_CALL_VEILEDERTILGANG_USER_FAIL = "${METRIC_CALL_VEILEDERTILGANG_BASE}_user_fail"
+
+        const val TILGANGSKONTROLL_COMMON_PATH = "/api/tilgang/navident"
+        const val TILGANGSKONTROLL_PERSON_PATH = "$TILGANGSKONTROLL_COMMON_PATH/person"
+        const val TILGANGSKONTROLL_SYFO_PATH = "$TILGANGSKONTROLL_COMMON_PATH/syfo"
+    }
+
+    data class Tilgang(
+        val erGodkjent: Boolean,
+    )
+}

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/mapper/OppfoelgingsdialogRestMapper.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/mapper/OppfoelgingsdialogRestMapper.kt
@@ -1,0 +1,59 @@
+package no.nav.syfo.oppfolgingsplan.mapper
+
+import no.nav.syfo.oppfolgingsplan.domain.GodkjentPlanDTO
+import no.nav.syfo.oppfolgingsplan.domain.OppfolgingsplanDTO
+import no.nav.syfo.oppfolgingsplan.domain.rs.RSGodkjentPlan
+import no.nav.syfo.oppfolgingsplan.domain.rs.RSGyldighetstidspunkt
+import no.nav.syfo.oppfolgingsplan.domain.rs.RSOppfoelgingsdialog
+import no.nav.syfo.oppfolgingsplan.domain.rs.RSVirksomhet
+import java.time.LocalDate
+
+fun godkjentplan2rs(godkjentPlan: GodkjentPlanDTO): RSGodkjentPlan {
+    return RSGodkjentPlan(
+        deltMedNAV = godkjentPlan.deltMedNAV,
+        deltMedNAVTidspunkt = godkjentPlan.deltMedNAVTidspunkt,
+        deltMedFastlege = godkjentPlan.deltMedFastlege,
+        deltMedFastlegeTidspunkt = godkjentPlan.deltMedFastlegeTidspunkt,
+        dokumentUuid = godkjentPlan.dokumentUuid,
+        opprettetTidspunkt = godkjentPlan.opprettetTidspunkt,
+        tvungenGodkjenning = godkjentPlan.tvungenGodkjenning,
+        gyldighetstidspunkt = RSGyldighetstidspunkt(
+            fom = godkjentPlan.gyldighetstidspunkt.fom,
+            tom = godkjentPlan.gyldighetstidspunkt.tom,
+            evalueres = godkjentPlan.gyldighetstidspunkt.evalueres
+        )
+    )
+}
+
+fun status2rs(oppfoelgingsdialog: OppfolgingsplanDTO): String {
+    if (oppfoelgingsdialog.godkjentPlan == null) {
+        return "UNDER_ARBEID"
+    }
+
+    return when {
+        oppfoelgingsdialog.godkjentPlan.avbruttPlan != null -> {
+            "AVBRUTT"
+        }
+
+        oppfoelgingsdialog.godkjentPlan.gyldighetstidspunkt.tom?.isBefore(LocalDate.now()) == true -> {
+            "UTDATERT"
+        }
+
+        else -> "AKTIV"
+    }
+}
+
+fun oppfoelgingsdialog2rs(oppfoelgingsdialog: OppfolgingsplanDTO): RSOppfoelgingsdialog {
+    return RSOppfoelgingsdialog(
+        id = oppfoelgingsdialog.id,
+        uuid = oppfoelgingsdialog.uuid,
+        sistEndretAvAktoerId = oppfoelgingsdialog.sistEndretAvAktoerId,
+        sistEndretDato = oppfoelgingsdialog.sistEndretDato,
+        status = status2rs(oppfoelgingsdialog),
+        virksomhet = RSVirksomhet(
+            virksomhetsnummer = oppfoelgingsdialog.virksomhet.virksomhetsnummer,
+            navn = oppfoelgingsdialog.virksomhet.navn
+        ),
+        godkjentPlan = oppfoelgingsdialog.godkjentPlan?.let { godkjentplan2rs(it) }
+    )
+}

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/repository/dao/ArbeidsoppgaveDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/repository/dao/ArbeidsoppgaveDAO.kt
@@ -38,6 +38,7 @@ class ArbeidsoppgaveDAO(
         )
     }
 
+    @Suppress("LongMethod")
     fun create(arbeidsoppgave: ArbeidsoppgaveDTO): ArbeidsoppgaveDTO {
         val arbeidsoppgaveId =
             jdbcTemplate.queryForObject("SELECT NEXTVAL('ARBEIDSOPPGAVE_ID_SEQ')", Long::class.java)!!

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/repository/dao/ArbeidsoppgaveDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/repository/dao/ArbeidsoppgaveDAO.kt
@@ -1,0 +1,173 @@
+package no.nav.syfo.oppfolgingsplan.repository.dao
+
+import no.nav.syfo.oppfolgingsplan.domain.ArbeidsoppgaveDTO
+import no.nav.syfo.oppfolgingsplan.repository.domain.PArbeidsoppgave
+import no.nav.syfo.oppfolgingsplan.repository.domain.toArbeidsoppgaveDTOList
+import no.nav.syfo.oppfolgingsplan.repository.util.DbUtil.convert
+import no.nav.syfo.oppfolgingsplan.repository.util.DbUtil.sanitizeUserInput
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.jdbc.core.RowMapper
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import org.springframework.jdbc.core.support.SqlLobValue
+import org.springframework.stereotype.Repository
+import java.sql.ResultSet
+import java.sql.SQLException
+import java.sql.Types
+import java.time.LocalDateTime
+
+@Repository
+class ArbeidsoppgaveDAO(
+    private val jdbcTemplate: JdbcTemplate,
+    private val namedParameterJdbcTemplate: NamedParameterJdbcTemplate
+) {
+
+    fun arbeidsoppgaverByOppfoelgingsdialogId(oppfoelgingsdialogId: Long): List<ArbeidsoppgaveDTO> {
+        return jdbcTemplate.query(
+            "select * from arbeidsoppgave where oppfoelgingsdialog_id = ?",
+            ArbeidsoppgaveRowMapper(),
+            oppfoelgingsdialogId
+        ).toArbeidsoppgaveDTOList()
+    }
+
+    fun finnArbeidsoppgave(id: Long): PArbeidsoppgave? {
+        return jdbcTemplate.queryForObject(
+            "select * from arbeidsoppgave where arbeidsoppgave_id = ?",
+            ArbeidsoppgaveRowMapper(),
+            id
+        )
+    }
+
+    fun create(arbeidsoppgave: ArbeidsoppgaveDTO): ArbeidsoppgaveDTO {
+        val arbeidsoppgaveId =
+            jdbcTemplate.queryForObject("SELECT NEXTVAL('ARBEIDSOPPGAVE_ID_SEQ')", Long::class.java)!!
+        val namedParameters = MapSqlParameterSource()
+            .addValue("arbeidsoppgave_id", arbeidsoppgaveId)
+            .addValue("oppfoelgingsdialog_id", arbeidsoppgave.oppfoelgingsdialogId)
+            .addValue("navn", sanitizeUserInput(arbeidsoppgave.navn))
+            .addValue("er_vurdert_av_sykmeldt", arbeidsoppgave.erVurdertAvSykmeldt)
+            .addValue("opprettet_av", arbeidsoppgave.opprettetAvAktoerId)
+            .addValue("sist_endret_av", arbeidsoppgave.opprettetAvAktoerId)
+            .addValue("sist_endret_dato", LocalDateTime.now())
+            .addValue("opprettet_dato", LocalDateTime.now())
+            .addValue("gjennomfoering_status", arbeidsoppgave.gjennomfoering?.gjennomfoeringStatus)
+            .addValue("paa_annet_sted", arbeidsoppgave.gjennomfoering?.paaAnnetSted)
+            .addValue("med_mer_tid", arbeidsoppgave.gjennomfoering?.medMerTid)
+            .addValue("med_hjelp", arbeidsoppgave.gjennomfoering?.medHjelp)
+            .addValue(
+                "beskrivelse",
+                SqlLobValue(sanitizeUserInput(arbeidsoppgave.gjennomfoering?.kanBeskrivelse)),
+                Types.CLOB
+            )
+            .addValue(
+                "kan_ikke_beskrivelse",
+                SqlLobValue(sanitizeUserInput(arbeidsoppgave.gjennomfoering?.kanIkkeBeskrivelse)),
+                Types.CLOB
+            )
+
+        val sqlQuery = """
+            insert into arbeidsoppgave (
+                arbeidsoppgave_id,
+                oppfoelgingsdialog_id,
+                navn,
+                er_vurdert_av_sykmeldt,
+                opprettet_av,
+                sist_endret_av,
+                sist_endret_dato,
+                opprettet_dato,
+                paa_annet_sted,
+                med_mer_tid, 
+                med_hjelp, 
+                beskrivelse, 
+                kan_ikke_beskrivelse, 
+                gjennomfoering_status
+            ) values (
+                :arbeidsoppgave_id, 
+                :oppfoelgingsdialog_id, 
+                :navn,
+                :er_vurdert_av_sykmeldt, 
+                :opprettet_av, 
+                :sist_endret_av,
+                :sist_endret_dato, 
+                :opprettet_dato, 
+                :paa_annet_sted,
+                :med_mer_tid, 
+                :med_hjelp, 
+                :beskrivelse, 
+                :kan_ikke_beskrivelse,
+                :gjennomfoering_status
+            )
+        """
+
+        namedParameterJdbcTemplate.update(sqlQuery, namedParameters)
+        return arbeidsoppgave.copy(id = arbeidsoppgaveId)
+    }
+
+    fun update(arbeidsoppgave: ArbeidsoppgaveDTO): ArbeidsoppgaveDTO {
+        val namedParameters = MapSqlParameterSource()
+            .addValue("arbeidsoppgave_id", arbeidsoppgave.id)
+            .addValue("navn", sanitizeUserInput(arbeidsoppgave.navn))
+            .addValue("er_vurdert_av_sykmeldt", arbeidsoppgave.erVurdertAvSykmeldt)
+            .addValue("sist_endret_av", arbeidsoppgave.sistEndretAvAktoerId)
+            .addValue("sist_endret_dato", LocalDateTime.now())
+            .addValue("gjennomfoering_status", arbeidsoppgave.gjennomfoering?.gjennomfoeringStatus)
+            .addValue("paa_annet_sted", arbeidsoppgave.gjennomfoering?.paaAnnetSted)
+            .addValue("med_mer_tid", arbeidsoppgave.gjennomfoering?.medMerTid)
+            .addValue("med_hjelp", arbeidsoppgave.gjennomfoering?.medHjelp)
+            .addValue(
+                "beskrivelse",
+                SqlLobValue(sanitizeUserInput(arbeidsoppgave.gjennomfoering?.kanBeskrivelse)),
+                Types.CLOB
+            )
+            .addValue(
+                "kan_ikke_beskrivelse",
+                SqlLobValue(sanitizeUserInput(arbeidsoppgave.gjennomfoering?.kanIkkeBeskrivelse)),
+                Types.CLOB
+            )
+        namedParameterJdbcTemplate.update(
+            """
+            update arbeidsoppgave set 
+                navn = :navn, 
+                er_vurdert_av_sykmeldt = :er_vurdert_av_sykmeldt,
+                sist_endret_av = :sist_endret_av, 
+                sist_endret_dato = :sist_endret_dato, 
+                gjennomfoering_status = :gjennomfoering_status, 
+                paa_annet_sted = :paa_annet_sted,
+                med_mer_tid = :med_mer_tid, 
+                med_hjelp = :med_hjelp, 
+                beskrivelse = :beskrivelse, 
+                kan_ikke_beskrivelse = :kan_ikke_beskrivelse 
+            where arbeidsoppgave_id = :arbeidsoppgave_id
+        """,
+            namedParameters
+        )
+
+        return arbeidsoppgave
+    }
+
+    fun delete(id: Long) {
+        jdbcTemplate.update("delete from arbeidsoppgave where arbeidsoppgave_id = ?", id)
+    }
+
+    private class ArbeidsoppgaveRowMapper : RowMapper<PArbeidsoppgave> {
+        @Throws(SQLException::class)
+        override fun mapRow(rs: ResultSet, rowNum: Int): PArbeidsoppgave {
+            return PArbeidsoppgave(
+                id = rs.getLong("arbeidsoppgave_id"),
+                oppfoelgingsdialogId = rs.getLong("oppfoelgingsdialog_id"),
+                navn = rs.getString("navn"),
+                erVurdertAvSykmeldt = rs.getBoolean("er_vurdert_av_sykmeldt"),
+                opprettetAvAktoerId = rs.getString("opprettet_av"),
+                sistEndretAvAktoerId = rs.getString("sist_endret_av"),
+                sistEndretDato = convert(rs.getTimestamp("sist_endret_dato")),
+                opprettetDato = convert(rs.getTimestamp("opprettet_dato"))!!,
+                gjennomfoeringStatus = rs.getString("gjennomfoering_status"),
+                paaAnnetSted = rs.getBoolean("paa_annet_sted"),
+                medMerTid = rs.getBoolean("med_mer_tid"),
+                medHjelp = rs.getBoolean("med_hjelp"),
+                kanBeskrivelse = rs.getString("beskrivelse"),
+                kanIkkeBeskrivelse = rs.getString("kan_ikke_beskrivelse")
+            )
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/repository/dao/GodkjenningerDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/repository/dao/GodkjenningerDAO.kt
@@ -1,0 +1,74 @@
+package no.nav.syfo.oppfolgingsplan.repository.dao
+
+import no.nav.syfo.oppfolgingsplan.domain.GodkjenningDTO
+import no.nav.syfo.oppfolgingsplan.repository.domain.PGodkjenning
+import no.nav.syfo.oppfolgingsplan.repository.domain.toGodkjenningDTOList
+import no.nav.syfo.oppfolgingsplan.repository.util.DbUtil.convert
+import no.nav.syfo.oppfolgingsplan.repository.util.DbUtil.nesteSekvensverdi
+import no.nav.syfo.oppfolgingsplan.repository.util.DbUtil.sanitizeUserInput
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.jdbc.core.RowMapper
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import org.springframework.jdbc.core.support.SqlLobValue
+import org.springframework.stereotype.Repository
+import java.sql.ResultSet
+import java.sql.SQLException
+import java.sql.Types
+import java.time.LocalDateTime
+
+@Repository
+class GodkjenningerDAO(
+    private val jdbcTemplate: JdbcTemplate,
+    private val namedParameterJdbcTemplate: NamedParameterJdbcTemplate
+) {
+
+    fun godkjenningerByOppfoelgingsdialogId(oppfoelgingsdialogId: Long): List<GodkjenningDTO> {
+        val query = "select * from godkjenning where oppfoelgingsdialog_id = ?"
+        val godkjenninger = jdbcTemplate.query(query, GodkjenningerRowMapper(), oppfoelgingsdialogId)
+        return godkjenninger.toGodkjenningDTOList()
+    }
+
+    fun deleteAllByOppfoelgingsdialogId(oppfoelgingsdialogId: Long) {
+        jdbcTemplate.update("delete from godkjenning where oppfoelgingsdialog_id = ?", oppfoelgingsdialogId)
+    }
+
+    fun create(godkjenning: GodkjenningDTO) {
+        val godkjenningId = nesteSekvensverdi("GODKJENNING_ID_SEQ", jdbcTemplate)
+        val namedParameters = MapSqlParameterSource()
+            .addValue("godkjenning_id", godkjenningId)
+            .addValue("oppfoelgingsdialog_id", godkjenning.oppfoelgingsdialogId)
+            .addValue("aktoer_id", godkjenning.godkjentAvAktoerId)
+            .addValue("godkjent", godkjenning.godkjent)
+            .addValue("beskrivelse", SqlLobValue(sanitizeUserInput(godkjenning.beskrivelse)), Types.CLOB)
+            .addValue("fom", convert(godkjenning.gyldighetstidspunkt?.fom))
+            .addValue("tom", convert(godkjenning.gyldighetstidspunkt?.tom))
+            .addValue("evalueres", convert(godkjenning.gyldighetstidspunkt?.evalueres))
+            .addValue("del_med_nav", godkjenning.delMedNav)
+            .addValue("created", convert(LocalDateTime.now()))
+        namedParameterJdbcTemplate.update(
+            "insert into godkjenning " +
+                "(godkjenning_id, oppfoelgingsdialog_id, aktoer_id, godkjent, beskrivelse, fom, tom, evalueres, del_med_nav, created) values" +
+                "(:godkjenning_id, :oppfoelgingsdialog_id, :aktoer_id, :godkjent, :beskrivelse, :fom, :tom, :evalueres, :del_med_nav, :created)",
+            namedParameters
+        )
+    }
+
+    private inner class GodkjenningerRowMapper : RowMapper<PGodkjenning> {
+        @Throws(SQLException::class)
+        override fun mapRow(rs: ResultSet, rowNum: Int): PGodkjenning {
+            return PGodkjenning(
+                id = rs.getLong("godkjenning_id"),
+                oppfoelgingsdialogId = rs.getLong("oppfoelgingsdialog_id"),
+                aktoerId = rs.getString("aktoer_id"),
+                godkjent = rs.getBoolean("godkjent"),
+                beskrivelse = rs.getString("beskrivelse"),
+                fom = convert(rs.getTimestamp("fom")),
+                tom = convert(rs.getTimestamp("tom")),
+                evalueres = convert(rs.getTimestamp("evalueres")),
+                delMedNav = rs.getBoolean("del_med_nav"),
+                created = convert(rs.getTimestamp("created"))!!
+            )
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/repository/dao/GodkjenningerDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/repository/dao/GodkjenningerDAO.kt
@@ -47,9 +47,12 @@ class GodkjenningerDAO(
             .addValue("del_med_nav", godkjenning.delMedNav)
             .addValue("created", convert(LocalDateTime.now()))
         namedParameterJdbcTemplate.update(
-            "insert into godkjenning " +
-                "(godkjenning_id, oppfoelgingsdialog_id, aktoer_id, godkjent, beskrivelse, fom, tom, evalueres, del_med_nav, created) values" +
-                "(:godkjenning_id, :oppfoelgingsdialog_id, :aktoer_id, :godkjent, :beskrivelse, :fom, :tom, :evalueres, :del_med_nav, :created)",
+            """
+                insert into godkjenning 
+                (godkjenning_id, oppfoelgingsdialog_id, aktoer_id, godkjent, beskrivelse, fom, tom, evalueres, del_med_nav, created) 
+                values(:godkjenning_id, :oppfoelgingsdialog_id, :aktoer_id, :godkjent, 
+                :beskrivelse, :fom, :tom, :evalueres, :del_med_nav, :created)
+                """,
             namedParameters
         )
     }

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/repository/dao/GodkjentplanDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/repository/dao/GodkjentplanDAO.kt
@@ -58,11 +58,13 @@ class GodkjentplanDAO(
             .addValue("delt_med_nav_tidspunkt", convert(godkjentPlan.deltMedNAVTidspunkt))
             .addValue("delt_med_fastlege", false)
         namedParameterJdbcTemplate.update(
-            "INSERT INTO godkjentplan " +
-                "(godkjentplan_id, oppfoelgingsdialog_id, dokument_uuid, created, fom, tom, evalueres, tvungen_godkjenning, " +
-                "delt_med_nav, delt_med_nav_tidspunkt, delt_med_fastlege) " +
-                "VALUES(:godkjentplan_id, :oppfoelgingsdialog_id, :dokument_uuid, :created, :fom, :tom, :evalueres, :tvungen_godkjenning, " +
-                ":delt_med_nav, :delt_med_nav_tidspunkt, :delt_med_fastlege)",
+            """
+                INSERT INTO godkjentplan 
+                (godkjentplan_id, oppfoelgingsdialog_id, dokument_uuid, created, fom, tom, evalueres, tvungen_godkjenning, 
+                delt_med_nav, delt_med_nav_tidspunkt, delt_med_fastlege) 
+                VALUES(:godkjentplan_id, :oppfoelgingsdialog_id, :dokument_uuid, :created, :fom, :tom, :evalueres, :tvungen_godkjenning, 
+                :delt_med_nav, :delt_med_nav_tidspunkt, :delt_med_fastlege)
+                """,
             namedParameters
         )
         return godkjentPlan.copy(id = id)
@@ -102,7 +104,8 @@ class GodkjentplanDAO(
 
     fun delMedFastlege(oppfolgingsplanId: Long) {
         jdbcTemplate.update(
-            "UPDATE godkjentplan SET delt_med_fastlege = 1, delt_med_fastlege_tidspunkt = ? WHERE oppfoelgingsdialog_id = ?",
+            "UPDATE godkjentplan SET delt_med_fastlege = 1, " +
+                "delt_med_fastlege_tidspunkt = ? WHERE oppfoelgingsdialog_id = ?",
             convert(LocalDateTime.now()),
             oppfolgingsplanId
         )

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/repository/dao/GodkjentplanDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/repository/dao/GodkjentplanDAO.kt
@@ -1,0 +1,135 @@
+package no.nav.syfo.oppfolgingsplan.repository.dao
+
+import no.nav.syfo.oppfolgingsplan.domain.GodkjentPlanDTO
+import no.nav.syfo.oppfolgingsplan.repository.domain.PGodkjentPlan
+import no.nav.syfo.oppfolgingsplan.repository.domain.toGodkjentPlanDTO
+import no.nav.syfo.oppfolgingsplan.repository.domain.toGodkjentPlanDTOList
+import no.nav.syfo.oppfolgingsplan.repository.util.DbUtil.convert
+import no.nav.syfo.oppfolgingsplan.repository.util.DbUtil.nesteSekvensverdi
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.jdbc.core.RowMapper
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import org.springframework.stereotype.Repository
+import java.sql.ResultSet
+import java.sql.SQLException
+import java.time.LocalDateTime
+
+@Repository
+class GodkjentplanDAO(
+    private val jdbcTemplate: JdbcTemplate,
+    private val namedParameterJdbcTemplate: NamedParameterJdbcTemplate,
+) {
+
+    fun godkjentPlanByOppfolgingsplanId(oppfolgingsplanId: Long): GodkjentPlanDTO? {
+        val query = "SELECT * FROM godkjentplan WHERE oppfoelgingsdialog_id = ?"
+        val godkjentPlan = jdbcTemplate.query(query, GodkjentPlanRowMapper(), oppfolgingsplanId)
+        return godkjentPlan.firstOrNull()?.toGodkjentPlanDTO()
+    }
+
+    fun godkjentPlanIdByOppfolgingsplanId(oppfolgingsplanId: Long): Long {
+        return jdbcTemplate.queryForObject(
+            "SELECT godkjentplan_id FROM godkjentplan WHERE oppfoelgingsdialog_id = ?",
+            Long::class.java,
+            oppfolgingsplanId
+        )
+    }
+
+    fun hentIkkeJournalfoertePlaner(): List<GodkjentPlanDTO> {
+        val godkjentePlaner = jdbcTemplate.query(
+            "SELECT * FROM godkjentplan WHERE journalpost_id IS NULL AND delt_med_nav = 1",
+            GodkjentPlanRowMapper()
+        )
+        return godkjentePlaner.toGodkjentPlanDTOList()
+    }
+
+    fun create(godkjentPlan: GodkjentPlanDTO): GodkjentPlanDTO {
+        val id = nesteSekvensverdi("GODKJENTPLAN_ID_SEQ", jdbcTemplate)
+        val namedParameters = MapSqlParameterSource()
+            .addValue("godkjentplan_id", id)
+            .addValue("oppfoelgingsdialog_id", godkjentPlan.oppfoelgingsdialogId)
+            .addValue("dokument_uuid", godkjentPlan.dokumentUuid)
+            .addValue("created", convert(LocalDateTime.now()))
+            .addValue("fom", convert(godkjentPlan.gyldighetstidspunkt.fom?.atStartOfDay()))
+            .addValue("tom", convert(godkjentPlan.gyldighetstidspunkt.tom?.atStartOfDay()))
+            .addValue("evalueres", convert(godkjentPlan.gyldighetstidspunkt.evalueres?.atStartOfDay()))
+            .addValue("tvungen_godkjenning", godkjentPlan.tvungenGodkjenning)
+            .addValue("delt_med_nav", godkjentPlan.deltMedNAV)
+            .addValue("delt_med_nav_tidspunkt", convert(godkjentPlan.deltMedNAVTidspunkt))
+            .addValue("delt_med_fastlege", false)
+        namedParameterJdbcTemplate.update(
+            "INSERT INTO godkjentplan " +
+                "(godkjentplan_id, oppfoelgingsdialog_id, dokument_uuid, created, fom, tom, evalueres, tvungen_godkjenning, " +
+                "delt_med_nav, delt_med_nav_tidspunkt, delt_med_fastlege) " +
+                "VALUES(:godkjentplan_id, :oppfoelgingsdialog_id, :dokument_uuid, :created, :fom, :tom, :evalueres, :tvungen_godkjenning, " +
+                ":delt_med_nav, :delt_med_nav_tidspunkt, :delt_med_fastlege)",
+            namedParameters
+        )
+        return godkjentPlan.copy(id = id)
+    }
+
+    fun sakId(oppfolgingsplanId: Long, sakId: String) {
+        jdbcTemplate.update(
+            "UPDATE godkjentplan SET sak_id = ? WHERE oppfoelgingsdialog_id = ?",
+            sakId,
+            oppfolgingsplanId
+        )
+    }
+
+    fun journalpostId(oppfolgingsplanId: Long, journalpostId: String) {
+        jdbcTemplate.update(
+            "UPDATE godkjentplan SET journalpost_id = ? WHERE oppfoelgingsdialog_id = ?",
+            journalpostId,
+            oppfolgingsplanId
+        )
+    }
+
+    fun delMedNav(oppfolgingsplanId: Long, deltMedNavTidspunkt: LocalDateTime) {
+        jdbcTemplate.update(
+            "UPDATE godkjentplan SET delt_med_nav = 1, delt_med_nav_tidspunkt = ? WHERE oppfoelgingsdialog_id = ?",
+            convert(deltMedNavTidspunkt),
+            oppfolgingsplanId
+        )
+    }
+
+    fun delMedNavTildelEnhet(oppfolgingsplanId: Long) {
+        jdbcTemplate.update(
+            "UPDATE godkjentplan SET tildelt_enhet = ? WHERE oppfoelgingsdialog_id = ?",
+            "",
+            oppfolgingsplanId
+        )
+    }
+
+    fun delMedFastlege(oppfolgingsplanId: Long) {
+        jdbcTemplate.update(
+            "UPDATE godkjentplan SET delt_med_fastlege = 1, delt_med_fastlege_tidspunkt = ? WHERE oppfoelgingsdialog_id = ?",
+            convert(LocalDateTime.now()),
+            oppfolgingsplanId
+        )
+    }
+
+    private inner class GodkjentPlanRowMapper : RowMapper<PGodkjentPlan> {
+        @Throws(SQLException::class)
+        override fun mapRow(rs: ResultSet, rowNum: Int): PGodkjentPlan {
+            return PGodkjentPlan(
+                id = rs.getLong("godkjentplan_id"),
+                oppfoelgingsdialogId = rs.getLong("oppfoelgingsdialog_id"),
+                dokumentUuid = rs.getString("dokument_uuid"),
+                created = convert(rs.getTimestamp("created"))!!,
+                fom = convert(rs.getTimestamp("fom")),
+                tom = convert(rs.getTimestamp("tom")),
+                evalueres = convert(rs.getTimestamp("evalueres")),
+                deltMedNavTidspunkt = convert(rs.getTimestamp("delt_med_nav_tidspunkt")),
+                deltMedFastlegeTidspunkt = convert(rs.getTimestamp("delt_med_fastlege_tidspunkt")),
+                tvungenGodkjenning = rs.getBoolean("tvungen_godkjenning"),
+                deltMedNav = rs.getBoolean("delt_med_nav"),
+                deltMedFastlege = rs.getBoolean("delt_med_fastlege"),
+                avbruttTidspunkt = convert(rs.getTimestamp("avbrutt_tidspunkt")),
+                avbruttAv = rs.getString("avbrutt_av"),
+                sakId = rs.getString("sak_id"),
+                journalpostId = rs.getString("journalpost_id"),
+                tildeltEnhet = rs.getString("tildelt_enhet")
+            )
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/repository/dao/KommentarDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/repository/dao/KommentarDAO.kt
@@ -28,7 +28,7 @@ class KommentarDAO(
         if (pKommentar != null) {
             return pKommentar.toKommentarDTO()
         } else {
-            throw RuntimeException("No Kommentar was found in database with given ID")
+            throw KommentarNotFoundException("No Kommentar was found in database with given ID")
         }
     }
 
@@ -56,8 +56,11 @@ class KommentarDAO(
             .addValue("opprettet_av", kommentar.opprettetAvAktoerId)
             .addValue("opprettet_dato", DbUtil.convert(LocalDateTime.now()))
         namedParameterJdbcTemplate.update(
-            "INSERT INTO kommentar (kommentar_id, tiltak_id, tekst, sist_endret_av, sist_endret_dato, opprettet_av, opprettet_dato) " +
-                "VALUES(:kommentar_id, :tiltak_id, :tekst, :sist_endret_av, :sist_endret_dato, :opprettet_av, :opprettet_dato)",
+            """
+                INSERT INTO kommentar 
+                (kommentar_id, tiltak_id, tekst, sist_endret_av, sist_endret_dato, opprettet_av, opprettet_dato) 
+                VALUES(:kommentar_id, :tiltak_id, :tekst, :sist_endret_av, :sist_endret_dato, :opprettet_av, :opprettet_dato)
+                """,
             namedParameters
         )
         return kommentar.copy(id = id)
@@ -97,4 +100,6 @@ class KommentarDAO(
             return pKommentar
         }
     }
+
+    class KommentarNotFoundException(message: String) : Exception(message)
 }

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/repository/dao/KommentarDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/repository/dao/KommentarDAO.kt
@@ -1,0 +1,100 @@
+package no.nav.syfo.oppfolgingsplan.repository.dao
+
+import no.nav.syfo.oppfolgingsplan.domain.KommentarDTO
+import no.nav.syfo.oppfolgingsplan.repository.domain.PKommentar
+import no.nav.syfo.oppfolgingsplan.repository.domain.toKommentarDTO
+import no.nav.syfo.oppfolgingsplan.repository.util.DbUtil
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.jdbc.core.RowMapper
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import org.springframework.jdbc.core.support.SqlLobValue
+import org.springframework.stereotype.Repository
+import java.sql.ResultSet
+import java.sql.SQLException
+import java.sql.Types
+import java.time.LocalDateTime
+import java.util.*
+import java.util.stream.Collectors
+
+@Repository
+class KommentarDAO(
+    private val jdbcTemplate: JdbcTemplate,
+    private val namedParameterJdbcTemplate: NamedParameterJdbcTemplate
+) {
+    fun finnKommentar(id: Long): KommentarDTO {
+        val pKommentar =
+            (jdbcTemplate.queryForObject("SELECT * FROM kommentar WHERE kommentar_id = ?", KommentarRowMapper(), id))
+        if (pKommentar != null) {
+            return pKommentar.toKommentarDTO()
+        } else {
+            throw RuntimeException("No Kommentar was found in database with given ID")
+        }
+    }
+
+    fun finnKommentarerByTiltakId(tiltakId: Long): List<KommentarDTO> {
+        val kommentarList = Optional.ofNullable(
+            jdbcTemplate.query(
+                "SELECT * FROM kommentar WHERE tiltak_id = ?",
+                KommentarRowMapper(),
+                tiltakId
+            )
+        ).orElse(emptyList())
+        return kommentarList.stream()
+            .map { pKommentar: PKommentar -> pKommentar.toKommentarDTO() }
+            .collect(Collectors.toList())
+    }
+
+    fun create(kommentar: KommentarDTO): KommentarDTO {
+        val id = DbUtil.nesteSekvensverdi("KOMMENTAR_ID_SEQ", jdbcTemplate)
+        val namedParameters = MapSqlParameterSource()
+            .addValue("kommentar_id", id)
+            .addValue("tiltak_id", kommentar.tiltakId)
+            .addValue("tekst", SqlLobValue(DbUtil.sanitizeUserInput(kommentar.tekst)), Types.CLOB)
+            .addValue("sist_endret_av", kommentar.sistEndretAvAktoerId)
+            .addValue("sist_endret_dato", DbUtil.convert(LocalDateTime.now()))
+            .addValue("opprettet_av", kommentar.opprettetAvAktoerId)
+            .addValue("opprettet_dato", DbUtil.convert(LocalDateTime.now()))
+        namedParameterJdbcTemplate.update(
+            "INSERT INTO kommentar (kommentar_id, tiltak_id, tekst, sist_endret_av, sist_endret_dato, opprettet_av, opprettet_dato) " +
+                "VALUES(:kommentar_id, :tiltak_id, :tekst, :sist_endret_av, :sist_endret_dato, :opprettet_av, :opprettet_dato)",
+            namedParameters
+        )
+        return kommentar.copy(id = id)
+    }
+
+    fun delete(id: Long?) {
+        jdbcTemplate.update("DELETE FROM kommentar WHERE kommentar_id = ?", id)
+    }
+
+    fun update(kommentar: KommentarDTO): KommentarDTO {
+        val namedParameters = MapSqlParameterSource()
+            .addValue("kommentar_id", kommentar.id)
+            .addValue("tekst", SqlLobValue(DbUtil.sanitizeUserInput(kommentar.tekst)), Types.CLOB)
+            .addValue("sist_endret_av", kommentar.sistEndretAvAktoerId)
+            .addValue("sist_endret_dato", DbUtil.convert(LocalDateTime.now()))
+        namedParameterJdbcTemplate.update(
+            "UPDATE kommentar " +
+                "SET tekst = :tekst, sist_endret_av = :sist_endret_av, sist_endret_dato = :sist_endret_dato " +
+                "WHERE kommentar_id = :kommentar_id",
+            namedParameters
+        )
+        return kommentar
+    }
+
+    private inner class KommentarRowMapper : RowMapper<PKommentar> {
+        @Throws(SQLException::class)
+        override fun mapRow(rs: ResultSet, rowNum: Int): PKommentar {
+            val pKommentar = PKommentar(
+                id = rs.getLong("kommentar_id"),
+                tiltakId = rs.getLong("tiltak_id"),
+                tekst = rs.getString("tekst"),
+                sistEndretAvAktoerId = rs.getString("sist_endret_av"),
+                sistEndretDato = DbUtil.convert(rs.getTimestamp("sist_endret_dato")),
+                opprettetAvAktoerId = rs.getString("opprettet_av"),
+                opprettetDato = DbUtil.convert(rs.getTimestamp("opprettet_dato"))
+            )
+            return pKommentar
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/repository/dao/OppfolgingsplanDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/repository/dao/OppfolgingsplanDAO.kt
@@ -1,5 +1,6 @@
 package no.nav.syfo.oppfolgingsplan.repository.dao
 
+import no.nav.syfo.exception.OppfolgingsplanNotFoundException
 import no.nav.syfo.oppfolgingsplan.domain.GodkjenningDTO
 import no.nav.syfo.oppfolgingsplan.domain.OppfolgingsplanDTO
 import no.nav.syfo.oppfolgingsplan.repository.domain.POppfoelgingsdialog
@@ -53,13 +54,15 @@ class OppfolgingsplanDAO(
             .addValue("sist_endret_av_fnr", oppfolgingsplan.sistEndretAvFnr)
 
         namedParameterJdbcTemplate.update(
-            "insert into oppfoelgingsdialog " +
-                "(oppfoelgingsdialog_id, uuid, aktoer_id, virksomhetsnummer, opprettet_av, created, arbeidsgiver_sist_innlogget, " +
-                "sykmeldt_sist_innlogget, sist_endret_av, sist_endret, arbeidsgiver_sist_aksessert, sykmeldt_sist_aksessert, " +
-                "arbeidsgiver_sist_endret, sykmeldt_sist_endret, samtykke_sykmeldt, samtykke_arbeidsgiver, sm_fnr, opprettet_av_fnr, sist_endret_av_fnr) " +
-                "values(:oppfoelgingsdialog_id, :uuid, :aktoer_id, :virksomhetsnummer, :opprettet_av, :created, :arbeidsgiver_sist_innlogget, " +
-                ":sykmeldt_sist_innlogget, :sist_endret_av, :sist_endret, :arbeidsgiver_sist_aksessert, :sykmeldt_sist_aksessert, " +
-                ":arbeidsgiver_sist_endret, :sykmeldt_sist_endret, :samtykke_sykmeldt, :samtykke_arbeidsgiver, :sm_fnr, :opprettet_av_fnr, :sist_endret_av_fnr)",
+            """
+                insert into oppfoelgingsdialog 
+                (oppfoelgingsdialog_id, uuid, aktoer_id, virksomhetsnummer, opprettet_av, created, arbeidsgiver_sist_innlogget, 
+                sykmeldt_sist_innlogget, sist_endret_av, sist_endret, arbeidsgiver_sist_aksessert, sykmeldt_sist_aksessert, 
+                arbeidsgiver_sist_endret, sykmeldt_sist_endret, samtykke_sykmeldt, samtykke_arbeidsgiver, sm_fnr, opprettet_av_fnr, sist_endret_av_fnr) 
+                values(:oppfoelgingsdialog_id, :uuid, :aktoer_id, :virksomhetsnummer, :opprettet_av, :created, :arbeidsgiver_sist_innlogget, 
+                :sykmeldt_sist_innlogget, :sist_endret_av, :sist_endret, :arbeidsgiver_sist_aksessert, :sykmeldt_sist_aksessert, 
+                :arbeidsgiver_sist_endret, :sykmeldt_sist_endret, :samtykke_sykmeldt, :samtykke_arbeidsgiver, :sm_fnr, :opprettet_av_fnr, :sist_endret_av_fnr)
+                """,
             namedParameters
         )
 
@@ -125,11 +128,12 @@ class OppfolgingsplanDAO(
 
     fun sistEndretAv(oppfoelgingsplanId: Long, innloggetAktoerId: String) {
         val oppfolgingsplan = finnOppfolgingsplanMedId(oppfoelgingsplanId)
-            ?: throw RuntimeException("Could not find oppfolgingsplan")
+            ?: throw OppfolgingsplanNotFoundException("Could not find oppfolgingsplan")
 
         if (erArbeidstakeren(oppfolgingsplan, innloggetAktoerId)) {
             jdbcTemplate.update(
-                "update oppfoelgingsdialog set sykmeldt_sist_endret = ?, sist_endret = ?, sist_endret_av = ? where oppfoelgingsdialog_id = ?",
+                "update oppfoelgingsdialog set sykmeldt_sist_endret = ?, " +
+                    "sist_endret = ?, sist_endret_av = ? where oppfoelgingsdialog_id = ?",
                 convert(LocalDateTime.now()),
                 convert(LocalDateTime.now()),
                 innloggetAktoerId,
@@ -137,7 +141,8 @@ class OppfolgingsplanDAO(
             )
         } else {
             jdbcTemplate.update(
-                "update oppfoelgingsdialog set arbeidsgiver_sist_endret = ?, sist_endret = ?, sist_endret_av = ? where oppfoelgingsdialog_id = ?",
+                "update oppfoelgingsdialog set arbeidsgiver_sist_endret = ?, " +
+                    "sist_endret = ?, sist_endret_av = ? where oppfoelgingsdialog_id = ?",
                 convert(LocalDateTime.now()),
                 convert(LocalDateTime.now()),
                 innloggetAktoerId,

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/repository/dao/OppfolgingsplanDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/repository/dao/OppfolgingsplanDAO.kt
@@ -1,0 +1,283 @@
+package no.nav.syfo.oppfolgingsplan.repository.dao
+
+import no.nav.syfo.oppfolgingsplan.domain.GodkjenningDTO
+import no.nav.syfo.oppfolgingsplan.domain.OppfolgingsplanDTO
+import no.nav.syfo.oppfolgingsplan.repository.domain.POppfoelgingsdialog
+import no.nav.syfo.oppfolgingsplan.repository.domain.toOppfolgingsplanDTO
+import no.nav.syfo.oppfolgingsplan.repository.domain.toOppfolgingsplanDTOList
+import no.nav.syfo.oppfolgingsplan.repository.util.DbUtil
+import no.nav.syfo.oppfolgingsplan.repository.util.DbUtil.convert
+import no.nav.syfo.oppfolgingsplan.util.erArbeidstakeren
+import org.slf4j.LoggerFactory
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.jdbc.core.RowMapper
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import org.springframework.stereotype.Repository
+import java.sql.ResultSet
+import java.sql.SQLException
+import java.time.LocalDateTime
+import java.util.*
+
+@Repository
+class OppfolgingsplanDAO(
+    private val jdbcTemplate: JdbcTemplate,
+    private val namedParameterJdbcTemplate: NamedParameterJdbcTemplate,
+    private val arbeidsoppgaveDAO: ArbeidsoppgaveDAO,
+    private val godkjenningerDAO: GodkjenningerDAO,
+    private val godkjentplanDAO: GodkjentplanDAO,
+    private val tiltakDAO: TiltakDAO
+) {
+
+    fun create(oppfolgingsplan: OppfolgingsplanDTO): OppfolgingsplanDTO {
+        val id = DbUtil.nesteSekvensverdi("OPPFOELGINGSDIALOG_ID_SEQ", jdbcTemplate)
+        val namedParameters = MapSqlParameterSource()
+            .addValue("oppfoelgingsdialog_id", id)
+            .addValue("uuid", UUID.randomUUID().toString())
+            .addValue("aktoer_id", oppfolgingsplan.arbeidstaker.aktoerId)
+            .addValue("virksomhetsnummer", oppfolgingsplan.virksomhet.virksomhetsnummer)
+            .addValue("opprettet_av", oppfolgingsplan.opprettetAvAktoerId)
+            .addValue("created", convert(LocalDateTime.now()))
+            .addValue("arbeidsgiver_sist_innlogget", convert(oppfolgingsplan.arbeidsgiver.sistInnlogget))
+            .addValue("sykmeldt_sist_innlogget", convert(oppfolgingsplan.arbeidstaker.sistInnlogget))
+            .addValue("sist_endret_av", oppfolgingsplan.sistEndretAvAktoerId)
+            .addValue("sist_endret", convert(LocalDateTime.now()))
+            .addValue("arbeidsgiver_sist_aksessert", convert(oppfolgingsplan.arbeidsgiver.sistAksessert))
+            .addValue("sykmeldt_sist_aksessert", convert(oppfolgingsplan.arbeidstaker.sistInnlogget))
+            .addValue("arbeidsgiver_sist_endret", convert(oppfolgingsplan.arbeidsgiver.sisteEndring))
+            .addValue("sykmeldt_sist_endret", convert(oppfolgingsplan.arbeidstaker.sisteEndring))
+            .addValue("samtykke_sykmeldt", null)
+            .addValue("samtykke_arbeidsgiver", null)
+            .addValue("sm_fnr", oppfolgingsplan.arbeidstaker.fnr)
+            .addValue("opprettet_av_fnr", oppfolgingsplan.opprettetAvFnr)
+            .addValue("sist_endret_av_fnr", oppfolgingsplan.sistEndretAvFnr)
+
+        namedParameterJdbcTemplate.update(
+            "insert into oppfoelgingsdialog " +
+                "(oppfoelgingsdialog_id, uuid, aktoer_id, virksomhetsnummer, opprettet_av, created, arbeidsgiver_sist_innlogget, " +
+                "sykmeldt_sist_innlogget, sist_endret_av, sist_endret, arbeidsgiver_sist_aksessert, sykmeldt_sist_aksessert, " +
+                "arbeidsgiver_sist_endret, sykmeldt_sist_endret, samtykke_sykmeldt, samtykke_arbeidsgiver, sm_fnr, opprettet_av_fnr, sist_endret_av_fnr) " +
+                "values(:oppfoelgingsdialog_id, :uuid, :aktoer_id, :virksomhetsnummer, :opprettet_av, :created, :arbeidsgiver_sist_innlogget, " +
+                ":sykmeldt_sist_innlogget, :sist_endret_av, :sist_endret, :arbeidsgiver_sist_aksessert, :sykmeldt_sist_aksessert, " +
+                ":arbeidsgiver_sist_endret, :sykmeldt_sist_endret, :samtykke_sykmeldt, :samtykke_arbeidsgiver, :sm_fnr, :opprettet_av_fnr, :sist_endret_av_fnr)",
+            namedParameters
+        )
+
+        return oppfolgingsplan.copy(id = id)
+    }
+
+    fun oppfolgingsplanByTiltakId(tiltakId: Long): OppfolgingsplanDTO? {
+        val query = """
+        select * from oppfoelgingsdialog join tiltak 
+        on tiltak.oppfoelgingsdialog_id = oppfoelgingsdialog.oppfoelgingsdialog_id 
+        where tiltak_id = ?
+    """
+        return jdbcTemplate.queryForObject(query, OppfoelgingsdialogRowMapper(), tiltakId)?.toOppfolgingsplanDTO()
+    }
+
+    fun finnOppfolgingsplanMedId(oppfoelgingsdialogId: Long): OppfolgingsplanDTO? {
+        return jdbcTemplate.queryForObject(
+            "select * from oppfoelgingsdialog where oppfoelgingsdialog_id = ?",
+            OppfoelgingsdialogRowMapper(),
+            oppfoelgingsdialogId
+        )?.toOppfolgingsplanDTO()
+    }
+
+    fun oppfolgingsplanerKnyttetTilSykmeldt(aktoerId: String): List<OppfolgingsplanDTO> {
+        return jdbcTemplate.query(
+            "select * from oppfoelgingsdialog where aktoer_id = ?",
+            OppfoelgingsdialogRowMapper(),
+            aktoerId
+        ).toOppfolgingsplanDTOList()
+    }
+
+    fun oppfolgingsplanerKnyttetTilSykmeldtogVirksomhet(
+        sykmeldtAktoerId: String,
+        virksomhetsnummer: String
+    ): List<OppfolgingsplanDTO> {
+        return jdbcTemplate.query(
+            "select * from oppfoelgingsdialog where aktoer_id = ? and virksomhetsnummer = ?",
+            OppfoelgingsdialogRowMapper(),
+            sykmeldtAktoerId,
+            virksomhetsnummer
+        ).toOppfolgingsplanDTOList()
+    }
+
+    fun populate(oppfolgingplan: OppfolgingsplanDTO): OppfolgingsplanDTO {
+        val arbeidsoppgaveListe = arbeidsoppgaveDAO.arbeidsoppgaverByOppfoelgingsdialogId(oppfolgingplan.id)
+        val tiltakListe = tiltakDAO.finnTiltakByOppfoelgingsdialogId(oppfolgingplan.id)
+        val godkjentPlan = godkjentplanDAO.godkjentPlanByOppfolgingsplanId(oppfolgingplan.id)
+        val godkjenninger = godkjenningerDAO.godkjenningerByOppfoelgingsdialogId(oppfolgingplan.id).also {
+            if (godkjentPlan != null && it.isNotEmpty()) {
+                log.warn("Sletter godkjenning som finnes selv om oppfølgingsplanen allerede er godkjent")
+                godkjenningerDAO.deleteAllByOppfoelgingsdialogId(godkjentPlan.oppfoelgingsdialogId)
+                emptyList<GodkjenningDTO>()
+            }
+        }
+
+        return oppfolgingplan.copy(
+            godkjentPlan = godkjentPlan,
+            godkjenninger = godkjenninger,
+            arbeidsoppgaveListe = arbeidsoppgaveListe,
+            tiltakListe = tiltakListe
+        )
+    }
+
+    fun sistEndretAv(oppfoelgingsplanId: Long, innloggetAktoerId: String) {
+        val oppfolgingsplan = finnOppfolgingsplanMedId(oppfoelgingsplanId)
+            ?: throw RuntimeException("Could not find oppfolgingsplan")
+
+        if (erArbeidstakeren(oppfolgingsplan, innloggetAktoerId)) {
+            jdbcTemplate.update(
+                "update oppfoelgingsdialog set sykmeldt_sist_endret = ?, sist_endret = ?, sist_endret_av = ? where oppfoelgingsdialog_id = ?",
+                convert(LocalDateTime.now()),
+                convert(LocalDateTime.now()),
+                innloggetAktoerId,
+                oppfoelgingsplanId
+            )
+        } else {
+            jdbcTemplate.update(
+                "update oppfoelgingsdialog set arbeidsgiver_sist_endret = ?, sist_endret = ?, sist_endret_av = ? where oppfoelgingsdialog_id = ?",
+                convert(LocalDateTime.now()),
+                convert(LocalDateTime.now()),
+                innloggetAktoerId,
+                oppfoelgingsplanId
+            )
+        }
+    }
+
+    fun lagreSamtykkeArbeidsgiver(oppfolgingplanId: Long, samtykke: Boolean) {
+        jdbcTemplate.update(
+            "update oppfoelgingsdialog set samtykke_arbeidsgiver = ? where oppfoelgingsdialog_id = ?",
+            samtykke,
+            oppfolgingplanId
+        )
+    }
+
+    fun lagreSamtykkeSykmeldt(oppfolgingsplanId: Long, samtykke: Boolean) {
+        jdbcTemplate.update(
+            "update oppfoelgingsdialog set samtykke_sykmeldt = ? where oppfoelgingsdialog_id = ?",
+            samtykke,
+            oppfolgingsplanId
+        )
+    }
+
+    fun oppdaterSistInnlogget(oppfolgingsplan: OppfolgingsplanDTO, innloggetAktoerId: String) {
+        if (innloggetAktoerId == oppfolgingsplan.arbeidstaker.aktoerId) {
+            jdbcTemplate.update(
+                "update oppfoelgingsdialog set sykmeldt_sist_innlogget = ? where oppfoelgingsdialog_id = ?",
+                convert(LocalDateTime.now()),
+                oppfolgingsplan.id
+            )
+        } else {
+            jdbcTemplate.update(
+                "update oppfoelgingsdialog set arbeidsgiver_sist_innlogget = ? where oppfoelgingsdialog_id = ?",
+                convert(LocalDateTime.now()),
+                oppfolgingsplan.id
+            )
+        }
+    }
+
+    fun oppdaterSistAksessert(oppfolgingsplan: OppfolgingsplanDTO, innloggetAktoerId: String) {
+        if (innloggetAktoerId == oppfolgingsplan.arbeidstaker.aktoerId) {
+            jdbcTemplate.update(
+                "update oppfoelgingsdialog set sykmeldt_sist_aksessert = ? where oppfoelgingsdialog_id = ?",
+                convert(LocalDateTime.now()),
+                oppfolgingsplan.id
+            )
+        } else {
+            jdbcTemplate.update(
+                "update oppfoelgingsdialog set arbeidsgiver_sist_aksessert = ? where oppfoelgingsdialog_id = ?",
+                convert(LocalDateTime.now()),
+                oppfolgingsplan.id
+            )
+        }
+    }
+
+    fun avbryt(oppfolgingsplanId: Long, innloggetAktoerId: String) {
+        jdbcTemplate.update(
+            "update godkjentplan set avbrutt_av = ?, avbrutt_tidspunkt = ? where oppfoelgingsdialog_id = ?",
+            innloggetAktoerId,
+            convert(LocalDateTime.now()),
+            oppfolgingsplanId
+        )
+    }
+
+    fun nullstillSamtykke(oppfolgingsplanId: Long) {
+        jdbcTemplate.update(
+            "update oppfoelgingsdialog set samtykke_sykmeldt = ? where oppfoelgingsdialog_id = ?",
+            null,
+            oppfolgingsplanId
+        )
+        jdbcTemplate.update(
+            "update oppfoelgingsdialog set samtykke_arbeidsgiver = ? where oppfoelgingsdialog_id = ?",
+            null,
+            oppfolgingsplanId
+        )
+    }
+
+    fun deleteOppfolgingsplan(oppfolgingsdialogId: Long) {
+        jdbcTemplate.update("DELETE ARBEIDSOPPGAVE WHERE OPPFOELGINGSDIALOG_ID = ?", oppfolgingsdialogId)
+        jdbcTemplate.query(
+            "SELECT * FROM TILTAK WHERE OPPFOELGINGSDIALOG_ID = ?",
+            { rs, rowNum -> rs.getString("TILTAK_ID") },
+            oppfolgingsdialogId
+        )
+            .forEach { tiltakId -> jdbcTemplate.update("DELETE KOMMENTAR WHERE TILTAK_ID = ?", tiltakId) }
+        jdbcTemplate.update("DELETE TILTAK WHERE OPPFOELGINGSDIALOG_ID = ?", oppfolgingsdialogId)
+        jdbcTemplate.update("DELETE GODKJENNING WHERE OPPFOELGINGSDIALOG_ID = ?", oppfolgingsdialogId)
+        jdbcTemplate.query(
+            "SELECT * from GODKJENTPLAN WHERE OPPFOELGINGSDIALOG_ID = ?",
+            { rs, rowNum -> rs.getString("DOKUMENT_UUID") },
+            oppfolgingsdialogId
+        )
+            .forEach { uuid -> jdbcTemplate.update("DELETE DOKUMENT WHERE DOKUMENT_UUID = ?", uuid) }
+        jdbcTemplate.query(
+            "SELECT * from GODKJENTPLAN WHERE OPPFOELGINGSDIALOG_ID = ?",
+            { rs, rowNum -> rs.getLong("GODKJENTPLAN_ID") },
+            oppfolgingsdialogId
+        )
+            .forEach { id -> jdbcTemplate.update("DELETE VEILEDER_BEHANDLING WHERE GODKJENTPLAN_ID = ?", id) }
+        jdbcTemplate.update("DELETE GODKJENTPLAN WHERE OPPFOELGINGSDIALOG_ID = ?", oppfolgingsdialogId)
+        jdbcTemplate.update("DELETE OPPFOELGINGSDIALOG WHERE OPPFOELGINGSDIALOG_ID = ?", oppfolgingsdialogId)
+    }
+
+    fun hentDialogIDerByAktoerId(aktoerId: String): List<Long> {
+        return jdbcTemplate.query(
+            "SELECT * FROM OPPFOELGINGSDIALOG WHERE AKTOER_ID = ?",
+            { rs, rowNum -> rs.getLong("OPPFOELGINGSDIALOG_ID") },
+            aktoerId
+        )
+    }
+
+    private inner class OppfoelgingsdialogRowMapper : RowMapper<POppfoelgingsdialog> {
+        @Throws(SQLException::class)
+        override fun mapRow(rs: ResultSet, rowNum: Int): POppfoelgingsdialog {
+            return POppfoelgingsdialog(
+                id = rs.getLong("oppfoelgingsdialog_id"),
+                uuid = rs.getString("uuid"),
+                aktoerId = rs.getString("aktoer_id"),
+                virksomhetsnummer = rs.getString("virksomhetsnummer"),
+                opprettetAv = rs.getString("opprettet_av"),
+                created = convert(rs.getTimestamp("created")),
+                sisteInnloggingArbeidsgiver = convert(rs.getTimestamp("arbeidsgiver_sist_innlogget")),
+                sisteInnloggingSykmeldt = convert(rs.getTimestamp("sykmeldt_sist_innlogget")),
+                sistEndretAv = rs.getString("sist_endret_av"),
+                sistEndret = convert(rs.getTimestamp("sist_endret")),
+                sistAksessertArbeidsgiver = convert(rs.getTimestamp("arbeidsgiver_sist_aksessert")),
+                sistAksessertSykmeldt = convert(rs.getTimestamp("sykmeldt_sist_aksessert")),
+                sistEndretArbeidsgiver = convert(rs.getTimestamp("arbeidsgiver_sist_endret")),
+                sistEndretSykmeldt = convert(rs.getTimestamp("sykmeldt_sist_endret")),
+                samtykkeSykmeldt = rs.getBoolean("samtykke_sykmeldt").let { if (rs.wasNull()) null else it },
+                samtykkeArbeidsgiver = rs.getBoolean("samtykke_arbeidsgiver").let { if (rs.wasNull()) null else it },
+                smFnr = rs.getString("sm_fnr"),
+                opprettetAvFnr = rs.getString("opprettet_av_fnr"),
+                sistEndretAvFnr = rs.getString("sist_endret_av_fnr")
+            )
+        }
+    }
+
+    companion object {
+        private val log = LoggerFactory.getLogger(OppfolgingsplanDAO::class.java)
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/repository/dao/TiltakDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/repository/dao/TiltakDAO.kt
@@ -1,0 +1,129 @@
+package no.nav.syfo.oppfolgingsplan.repository.dao
+
+import no.nav.syfo.oppfolgingsplan.domain.TiltakDTO
+import no.nav.syfo.oppfolgingsplan.repository.domain.PTiltak
+import no.nav.syfo.oppfolgingsplan.repository.domain.toTiltakDTO
+import no.nav.syfo.oppfolgingsplan.repository.util.DbUtil
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.jdbc.core.RowMapper
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import org.springframework.jdbc.core.support.SqlLobValue
+import org.springframework.stereotype.Repository
+import java.sql.ResultSet
+import java.sql.SQLException
+import java.sql.Types
+import java.time.LocalDateTime
+import java.util.*
+import java.util.stream.Collectors
+
+@Repository
+class TiltakDAO(
+    private val jdbcTemplate: JdbcTemplate,
+    private val namedParameterJdbcTemplate: NamedParameterJdbcTemplate,
+    private val kommentarDAO: KommentarDAO
+) {
+    fun finnTiltakByOppfoelgingsdialogId(oppfoelgingsdialogId: Long): List<TiltakDTO> {
+        val tiltakListe = Optional.ofNullable(
+            jdbcTemplate.query(
+                "SELECT * FROM tiltak WHERE oppfoelgingsdialog_id = ?",
+                TiltakRowMapper(),
+                oppfoelgingsdialogId
+            )
+        ).orElse(emptyList())
+        return tiltakListe
+            .stream()
+            .map { pTiltak: PTiltak -> pTiltak.toTiltakDTO(kommentarDAO.finnKommentarerByTiltakId(pTiltak.id)) }
+            .collect(Collectors.toList())
+    }
+
+    fun finnTiltakById(id: Long): TiltakDTO {
+        val pTiltak = jdbcTemplate.queryForObject("SELECT * FROM tiltak WHERE tiltak_id = ?", TiltakRowMapper(), id)
+        if (pTiltak != null) {
+            return pTiltak.toTiltakDTO(kommentarDAO.finnKommentarerByTiltakId(pTiltak.id))
+        } else {
+            throw RuntimeException("No Tiltak was found in database with given ID")
+        }
+    }
+
+    fun create(tiltak: TiltakDTO): TiltakDTO {
+        val id = DbUtil.nesteSekvensverdi("TILTAK_ID_SEQ", jdbcTemplate)
+        val namedParameters = MapSqlParameterSource()
+            .addValue("tiltak_id", id)
+            .addValue("oppfoelgingsdialog_id", tiltak.oppfoelgingsdialogId)
+            .addValue("navn", DbUtil.sanitizeUserInput(tiltak.navn))
+            .addValue("fom", DbUtil.convert(tiltak.fom))
+            .addValue("tom", DbUtil.convert(tiltak.tom))
+            .addValue("beskrivelse", SqlLobValue(DbUtil.sanitizeUserInput(tiltak.beskrivelse)), Types.CLOB)
+            .addValue(
+                "beskrivelse_ikke_aktuelt",
+                SqlLobValue(DbUtil.sanitizeUserInput(tiltak.beskrivelseIkkeAktuelt)),
+                Types.CLOB
+            )
+            .addValue("opprettet_av", tiltak.opprettetAvAktoerId)
+            .addValue("sist_endret_av", tiltak.sistEndretAvAktoerId)
+            .addValue("opprettet_dato", DbUtil.convert(LocalDateTime.now()))
+            .addValue("sist_endret_dato", DbUtil.convert(LocalDateTime.now()))
+            .addValue("status", tiltak.status)
+            .addValue("gjennomfoering", SqlLobValue(DbUtil.sanitizeUserInput(tiltak.gjennomfoering)), Types.CLOB)
+        namedParameterJdbcTemplate.update(
+            "INSERT INTO tiltak (tiltak_id, oppfoelgingsdialog_id, navn, fom, tom, beskrivelse, beskrivelse_ikke_aktuelt, " +
+                "opprettet_av, sist_endret_av, opprettet_dato, sist_endret_dato, status, gjennomfoering ) " +
+                "VALUES(:tiltak_id, :oppfoelgingsdialog_id, :navn, :fom, :tom, :beskrivelse, :beskrivelse_ikke_aktuelt, " +
+                ":opprettet_av, :sist_endret_av, :opprettet_dato, :sist_endret_dato, :status, :gjennomfoering)",
+            namedParameters
+        )
+        return tiltak.copy(id = id)
+    }
+
+    fun update(tiltak: TiltakDTO): TiltakDTO {
+        val namedParameters = MapSqlParameterSource()
+            .addValue("tiltak_id", tiltak.id)
+            .addValue("navn", DbUtil.sanitizeUserInput(tiltak.navn))
+            .addValue("fom", DbUtil.convert(tiltak.fom))
+            .addValue("tom", DbUtil.convert(tiltak.tom))
+            .addValue("beskrivelse", SqlLobValue(DbUtil.sanitizeUserInput(tiltak.beskrivelse)), Types.CLOB)
+            .addValue(
+                "beskrivelse_ikke_aktuelt",
+                SqlLobValue(DbUtil.sanitizeUserInput(tiltak.beskrivelseIkkeAktuelt)),
+                Types.CLOB
+            )
+            .addValue("sist_endret_av", tiltak.sistEndretAvAktoerId)
+            .addValue("sist_endret_dato", DbUtil.convert(LocalDateTime.now()))
+            .addValue("status", tiltak.status)
+            .addValue("gjennomfoering", SqlLobValue(DbUtil.sanitizeUserInput(tiltak.gjennomfoering)), Types.CLOB)
+        namedParameterJdbcTemplate.update(
+            "UPDATE tiltak SET navn = :navn, fom = :fom, tom = :tom, beskrivelse = :beskrivelse, beskrivelse_ikke_aktuelt = :beskrivelse_ikke_aktuelt, " +
+                "sist_endret_av = :sist_endret_av, sist_endret_dato = :sist_endret_dato, status = :status, gjennomfoering = :gjennomfoering WHERE " +
+                "tiltak_id = :tiltak_id",
+            namedParameters
+        )
+        return tiltak
+    }
+
+    fun deleteById(id: Long?) {
+        jdbcTemplate.update("DELETE FROM tiltak WHERE tiltak_id = ?", id)
+    }
+
+    private inner class TiltakRowMapper : RowMapper<PTiltak> {
+        @Throws(SQLException::class)
+        override fun mapRow(rs: ResultSet, rowNum: Int): PTiltak {
+            val pTiltak = PTiltak(
+                id = rs.getLong("tiltak_id"),
+                oppfoelgingsdialogId = rs.getLong("oppfoelgingsdialog_id"),
+                navn = rs.getString("navn"),
+                fom = DbUtil.convert(rs.getTimestamp("fom")),
+                tom = DbUtil.convert(rs.getTimestamp("tom")),
+                beskrivelse = rs.getString("beskrivelse"),
+                beskrivelseIkkeAktuelt = rs.getString("beskrivelse_ikke_aktuelt"),
+                opprettetAvAktoerId = rs.getString("opprettet_av"),
+                sistEndretAvAktoerId = rs.getString("sist_endret_av"),
+                sistEndretDato = DbUtil.convert(rs.getTimestamp("sist_endret_dato")),
+                opprettetDato = DbUtil.convert(rs.getTimestamp("opprettet_dato")),
+                status = rs.getString("status"),
+                gjennomfoering = rs.getString("gjennomfoering")
+            )
+            return pTiltak
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/repository/dao/TiltakDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/repository/dao/TiltakDAO.kt
@@ -1,5 +1,6 @@
 package no.nav.syfo.oppfolgingsplan.repository.dao
 
+import no.nav.syfo.exception.TiltakNotFoundException
 import no.nav.syfo.oppfolgingsplan.domain.TiltakDTO
 import no.nav.syfo.oppfolgingsplan.repository.domain.PTiltak
 import no.nav.syfo.oppfolgingsplan.repository.domain.toTiltakDTO
@@ -42,7 +43,7 @@ class TiltakDAO(
         if (pTiltak != null) {
             return pTiltak.toTiltakDTO(kommentarDAO.finnKommentarerByTiltakId(pTiltak.id))
         } else {
-            throw RuntimeException("No Tiltak was found in database with given ID")
+            throw TiltakNotFoundException("No Tiltak was found in database with given ID")
         }
     }
 
@@ -67,10 +68,12 @@ class TiltakDAO(
             .addValue("status", tiltak.status)
             .addValue("gjennomfoering", SqlLobValue(DbUtil.sanitizeUserInput(tiltak.gjennomfoering)), Types.CLOB)
         namedParameterJdbcTemplate.update(
-            "INSERT INTO tiltak (tiltak_id, oppfoelgingsdialog_id, navn, fom, tom, beskrivelse, beskrivelse_ikke_aktuelt, " +
-                "opprettet_av, sist_endret_av, opprettet_dato, sist_endret_dato, status, gjennomfoering ) " +
-                "VALUES(:tiltak_id, :oppfoelgingsdialog_id, :navn, :fom, :tom, :beskrivelse, :beskrivelse_ikke_aktuelt, " +
-                ":opprettet_av, :sist_endret_av, :opprettet_dato, :sist_endret_dato, :status, :gjennomfoering)",
+            """
+                INSERT INTO tiltak (tiltak_id, oppfoelgingsdialog_id, navn, fom, tom, beskrivelse, beskrivelse_ikke_aktuelt, 
+                opprettet_av, sist_endret_av, opprettet_dato, sist_endret_dato, status, gjennomfoering ) 
+                VALUES(:tiltak_id, :oppfoelgingsdialog_id, :navn, :fom, :tom, :beskrivelse, :beskrivelse_ikke_aktuelt, 
+                :opprettet_av, :sist_endret_av, :opprettet_dato, :sist_endret_dato, :status, :gjennomfoering)
+                """,
             namedParameters
         )
         return tiltak.copy(id = id)
@@ -93,9 +96,11 @@ class TiltakDAO(
             .addValue("status", tiltak.status)
             .addValue("gjennomfoering", SqlLobValue(DbUtil.sanitizeUserInput(tiltak.gjennomfoering)), Types.CLOB)
         namedParameterJdbcTemplate.update(
-            "UPDATE tiltak SET navn = :navn, fom = :fom, tom = :tom, beskrivelse = :beskrivelse, beskrivelse_ikke_aktuelt = :beskrivelse_ikke_aktuelt, " +
-                "sist_endret_av = :sist_endret_av, sist_endret_dato = :sist_endret_dato, status = :status, gjennomfoering = :gjennomfoering WHERE " +
-                "tiltak_id = :tiltak_id",
+            """
+                UPDATE tiltak SET navn = :navn, fom = :fom, tom = :tom, beskrivelse = :beskrivelse, beskrivelse_ikke_aktuelt = :beskrivelse_ikke_aktuelt, 
+                sist_endret_av = :sist_endret_av, sist_endret_dato = :sist_endret_dato, status = :status, gjennomfoering = :gjennomfoering WHERE 
+                tiltak_id = :tiltak_id
+                """,
             namedParameters
         )
         return tiltak

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/repository/domain/Dokument.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/repository/domain/Dokument.kt
@@ -1,0 +1,7 @@
+package no.nav.syfo.oppfolgingsplan.repository.domain
+
+data class Dokument(
+    val pdf: ByteArray,
+    val xml: String,
+    val uuid: String
+)

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/repository/domain/PArbeidsoppgave.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/repository/domain/PArbeidsoppgave.kt
@@ -1,0 +1,47 @@
+package no.nav.syfo.oppfolgingsplan.repository.domain
+
+import no.nav.syfo.oppfolgingsplan.domain.ArbeidsoppgaveDTO
+import no.nav.syfo.oppfolgingsplan.domain.GjennomfoeringDTO
+import java.time.LocalDateTime
+
+data class PArbeidsoppgave(
+    var id: Long,
+    var oppfoelgingsdialogId: Long,
+    var navn: String?,
+    var erVurdertAvSykmeldt: Boolean,
+    var opprettetAvAktoerId: String?,
+    var sistEndretAvAktoerId: String?,
+    var sistEndretDato: LocalDateTime?,
+    var opprettetDato: LocalDateTime,
+    var gjennomfoeringStatus: String?,
+    var paaAnnetSted: Boolean?,
+    var medMerTid: Boolean?,
+    var medHjelp: Boolean?,
+    var kanBeskrivelse: String?,
+    var kanIkkeBeskrivelse: String?
+)
+
+fun PArbeidsoppgave.toArbeidsoppgaveDTO(): ArbeidsoppgaveDTO {
+    return ArbeidsoppgaveDTO(
+        id = this.id,
+        oppfoelgingsdialogId = this.oppfoelgingsdialogId,
+        navn = this.navn,
+        erVurdertAvSykmeldt = this.erVurdertAvSykmeldt,
+        gjennomfoering = GjennomfoeringDTO(
+            gjennomfoeringStatus = this.gjennomfoeringStatus?.let { GjennomfoeringDTO.KanGjennomfoeres.valueOf(it) },
+            kanIkkeBeskrivelse = this.kanIkkeBeskrivelse,
+            kanBeskrivelse = this.kanBeskrivelse,
+            medMerTid = this.medMerTid,
+            medHjelp = this.medHjelp,
+            paaAnnetSted = this.paaAnnetSted,
+        ),
+        sistEndretAvAktoerId = this.sistEndretAvAktoerId,
+        sistEndretDato = this.sistEndretDato,
+        opprettetAvAktoerId = this.opprettetAvAktoerId,
+        opprettetDato = this.opprettetDato
+    )
+}
+
+fun List<PArbeidsoppgave>.toArbeidsoppgaveDTOList(): List<ArbeidsoppgaveDTO> {
+    return this.map { it.toArbeidsoppgaveDTO() }
+}

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/repository/domain/PAsynkoppgave.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/repository/domain/PAsynkoppgave.kt
@@ -1,0 +1,12 @@
+package no.nav.syfo.oppfolgingsplan.repository.domain
+
+import java.time.LocalDateTime
+
+data class PAsynkoppgave(
+    var id: Long?,
+    var opprettetTidspunkt: LocalDateTime?,
+    var oppgavetype: String?,
+    var avhengigAv: Long?,
+    var antallForsoek: Int,
+    var ressursId: String?
+)

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/repository/domain/PGodkjenning.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/repository/domain/PGodkjenning.kt
@@ -1,0 +1,39 @@
+package no.nav.syfo.oppfolgingsplan.repository.domain
+
+import no.nav.syfo.oppfolgingsplan.domain.GodkjenningDTO
+import no.nav.syfo.oppfolgingsplan.domain.GyldighetstidspunktDTO
+import java.time.LocalDateTime
+
+data class PGodkjenning(
+    var id: Long,
+    var oppfoelgingsdialogId: Long,
+    var created: LocalDateTime,
+    var aktoerId: String?,
+    var beskrivelse: String?,
+    var godkjent: Boolean,
+    var delMedNav: Boolean,
+    var fom: LocalDateTime?,
+    var tom: LocalDateTime?,
+    var evalueres: LocalDateTime?
+)
+
+fun PGodkjenning.toGodkjenningDTO(): GodkjenningDTO {
+    return GodkjenningDTO(
+        id = this.id,
+        oppfoelgingsdialogId = this.oppfoelgingsdialogId,
+        godkjent = this.godkjent,
+        delMedNav = this.delMedNav,
+        godkjentAvAktoerId = this.aktoerId,
+        beskrivelse = this.beskrivelse,
+        godkjenningsTidspunkt = this.created,
+        gyldighetstidspunkt = GyldighetstidspunktDTO(
+            fom = this.fom?.toLocalDate(),
+            tom = this.tom?.toLocalDate(),
+            evalueres = this.evalueres?.toLocalDate()
+        )
+    )
+}
+
+fun List<PGodkjenning>.toGodkjenningDTOList(): List<GodkjenningDTO> {
+    return this.map { it.toGodkjenningDTO() }
+}

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/repository/domain/PGodkjentPlan.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/repository/domain/PGodkjentPlan.kt
@@ -1,0 +1,58 @@
+package no.nav.syfo.oppfolgingsplan.repository.domain
+
+import no.nav.syfo.oppfolgingsplan.domain.AvbruttplanDTO
+import no.nav.syfo.oppfolgingsplan.domain.GodkjentPlanDTO
+import no.nav.syfo.oppfolgingsplan.domain.GyldighetstidspunktDTO
+import java.time.LocalDateTime
+
+data class PGodkjentPlan(
+    var id: Long,
+    var oppfoelgingsdialogId: Long,
+    var dokumentUuid: String?,
+    var sakId: String?,
+    var journalpostId: String?,
+    var tildeltEnhet: String?,
+    var deltMedNav: Boolean,
+    var deltMedFastlege: Boolean,
+    var tvungenGodkjenning: Boolean,
+    var avbruttTidspunkt: LocalDateTime?,
+    var avbruttAv: String?,
+    var fom: LocalDateTime?,
+    var tom: LocalDateTime?,
+    var evalueres: LocalDateTime?,
+    var deltMedNavTidspunkt: LocalDateTime?,
+    var deltMedFastlegeTidspunkt: LocalDateTime?,
+    var created: LocalDateTime
+)
+
+fun PGodkjentPlan.toGodkjentPlanDTO(): GodkjentPlanDTO {
+    return GodkjentPlanDTO(
+        id = this.id,
+        oppfoelgingsdialogId = this.oppfoelgingsdialogId,
+        opprettetTidspunkt = this.created,
+        gyldighetstidspunkt = GyldighetstidspunktDTO(
+            fom = this.fom?.toLocalDate(),
+            tom = this.tom?.toLocalDate(),
+            evalueres = this.evalueres?.toLocalDate()
+        ),
+        tvungenGodkjenning = this.tvungenGodkjenning,
+        deltMedNAVTidspunkt = this.deltMedNavTidspunkt,
+        deltMedNAV = this.deltMedNav,
+        deltMedFastlege = this.deltMedFastlege,
+        deltMedFastlegeTidspunkt = this.deltMedFastlegeTidspunkt,
+        dokumentUuid = this.dokumentUuid,
+        avbruttPlan = AvbruttplanDTO(
+            avAktoerId = this.avbruttAv,
+            tidspunkt = this.avbruttTidspunkt,
+            oppfoelgingsdialogId = this.oppfoelgingsdialogId
+        ),
+        sakId = this.sakId,
+        journalpostId = this.journalpostId,
+        tildeltEnhet = this.tildeltEnhet,
+        dokument = null
+    )
+}
+
+fun List<PGodkjentPlan>.toGodkjentPlanDTOList(): List<GodkjentPlanDTO> {
+    return this.map { it.toGodkjentPlanDTO() }
+}

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/repository/domain/PKommentar.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/repository/domain/PKommentar.kt
@@ -1,0 +1,26 @@
+package no.nav.syfo.oppfolgingsplan.repository.domain
+
+import no.nav.syfo.oppfolgingsplan.domain.KommentarDTO
+import java.time.LocalDateTime
+
+data class PKommentar(
+    var id: Long,
+    var tiltakId: Long,
+    var tekst: String?,
+    var sistEndretAvAktoerId: String?,
+    var sistEndretDato: LocalDateTime?,
+    var opprettetAvAktoerId: String?,
+    var opprettetDato: LocalDateTime?
+)
+
+fun PKommentar.toKommentarDTO(): KommentarDTO {
+    return KommentarDTO(
+        id = this.id,
+        tiltakId = this.tiltakId,
+        tekst = this.tekst,
+        sistEndretAvAktoerId = this.sistEndretAvAktoerId,
+        sistEndretDato = this.sistEndretDato,
+        opprettetAvAktoerId = this.opprettetAvAktoerId,
+        opprettetDato = this.opprettetDato
+    )
+}

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/repository/domain/POppfoelgingsdialog.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/repository/domain/POppfoelgingsdialog.kt
@@ -1,0 +1,78 @@
+package no.nav.syfo.oppfolgingsplan.repository.domain
+
+import no.nav.syfo.oppfolgingsplan.domain.OppfolgingsplanDTO
+import no.nav.syfo.oppfolgingsplan.domain.PersonDTO
+import no.nav.syfo.oppfolgingsplan.domain.VirksomhetDTO
+import java.time.LocalDateTime
+
+data class POppfoelgingsdialog(
+    var id: Long,
+    var uuid: String,
+    var opprettetAv: String?,
+    var aktoerId: String,
+    var created: LocalDateTime?,
+    var samtykkeArbeidsgiver: Boolean?,
+    var virksomhetsnummer: String?,
+    var sistEndretAv: String?,
+    var samtykkeSykmeldt: Boolean?,
+    var sisteInnloggingArbeidsgiver: LocalDateTime?,
+    var sisteInnloggingSykmeldt: LocalDateTime?,
+    var sistAksessertArbeidsgiver: LocalDateTime?,
+    var sistAksessertSykmeldt: LocalDateTime?,
+    var sistEndretArbeidsgiver: LocalDateTime?,
+    var sistEndretSykmeldt: LocalDateTime?,
+    var sistEndret: LocalDateTime?,
+    var smFnr: String?,
+    var opprettetAvFnr: String?,
+    var sistEndretAvFnr: String?
+)
+
+fun POppfoelgingsdialog.toOppfolgingsplanDTO(): OppfolgingsplanDTO {
+    return OppfolgingsplanDTO(
+        id = this.id,
+        uuid = this.uuid,
+        opprettet = this.created!!,
+        sistEndretAvAktoerId = this.sistEndretAv,
+        sistEndretAvFnr = this.sistEndretAvFnr,
+        opprettetAvAktoerId = this.opprettetAv,
+        opprettetAvFnr = this.opprettetAvFnr,
+        sistEndretDato = this.sistEndret,
+        sistEndretArbeidsgiver = this.sistEndretArbeidsgiver,
+        sistEndretSykmeldt = this.sistEndretSykmeldt,
+        status = null,
+        virksomhet = VirksomhetDTO(
+            navn = null,
+            virksomhetsnummer = this.virksomhetsnummer!!
+        ),
+        godkjentPlan = null,
+        godkjenninger = emptyList(),
+        arbeidsoppgaveListe = emptyList(),
+        arbeidsgiver = PersonDTO(
+            sistAksessert = this.sistAksessertArbeidsgiver,
+            sisteEndring = this.sistEndretArbeidsgiver,
+            sistInnlogget = this.sisteInnloggingArbeidsgiver,
+            samtykke = this.samtykkeArbeidsgiver,
+            aktoerId = null,
+            epost = null,
+            fnr = null,
+            navn = null,
+            tlf = null
+        ),
+        arbeidstaker = PersonDTO(
+            aktoerId = this.aktoerId,
+            fnr = this.smFnr,
+            sistAksessert = this.sistAksessertSykmeldt,
+            sisteEndring = this.sistEndretSykmeldt,
+            sistInnlogget = this.sisteInnloggingSykmeldt,
+            samtykke = this.samtykkeSykmeldt,
+            epost = null,
+            navn = null,
+            tlf = null
+        ),
+        tiltakListe = emptyList(),
+    )
+}
+
+fun List<POppfoelgingsdialog>.toOppfolgingsplanDTOList(): List<OppfolgingsplanDTO> {
+    return this.map { it.toOppfolgingsplanDTO() }
+}

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/repository/domain/PTiltak.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/repository/domain/PTiltak.kt
@@ -1,0 +1,40 @@
+package no.nav.syfo.oppfolgingsplan.repository.domain
+
+import no.nav.syfo.oppfolgingsplan.domain.KommentarDTO
+import no.nav.syfo.oppfolgingsplan.domain.TiltakDTO
+import java.time.LocalDateTime
+
+data class PTiltak(
+    var id: Long,
+    var oppfoelgingsdialogId: Long,
+    var navn: String?,
+    var fom: LocalDateTime?,
+    var tom: LocalDateTime?,
+    var beskrivelse: String?,
+    var opprettetAvAktoerId: String?,
+    var sistEndretAvAktoerId: String?,
+    var sistEndretDato: LocalDateTime?,
+    var opprettetDato: LocalDateTime?,
+    var status: String?,
+    var gjennomfoering: String?,
+    var beskrivelseIkkeAktuelt: String?
+)
+
+fun PTiltak.toTiltakDTO(kommentarer: List<KommentarDTO>): TiltakDTO {
+    return TiltakDTO(
+        id = this.id,
+        oppfoelgingsdialogId = this.oppfoelgingsdialogId,
+        navn = this.navn,
+        fom = this.fom?.toLocalDate(),
+        tom = this.tom?.toLocalDate(),
+        beskrivelse = this.beskrivelse,
+        beskrivelseIkkeAktuelt = this.beskrivelseIkkeAktuelt,
+        sistEndretAvAktoerId = this.sistEndretAvAktoerId,
+        sistEndretDato = this.sistEndretDato,
+        opprettetAvAktoerId = this.opprettetAvAktoerId,
+        opprettetDato = this.opprettetDato,
+        status = this.status,
+        gjennomfoering = this.gjennomfoering,
+        kommentarer = kommentarer
+    )
+}

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/repository/domain/PVeilederBehandling.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/repository/domain/PVeilederBehandling.kt
@@ -1,0 +1,15 @@
+package no.nav.syfo.oppfolgingsplan.repository.domain
+
+import java.time.LocalDateTime
+
+data class PVeilederBehandling(
+    var oppgaveId: Long,
+    var oppgaveUUID: String?,
+    var godkjentplanId: Long?,
+    var tildeltIdent: String?,
+    var tildeltEnhet: String?,
+    var opprettetDato: LocalDateTime?,
+    var sistEndret: LocalDateTime?,
+    var sistEndretAv: String?,
+    var status: String?
+)

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/repository/domain/VeilederBehandlingStatus.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/repository/domain/VeilederBehandlingStatus.kt
@@ -1,0 +1,6 @@
+package no.nav.syfo.oppfolgingsplan.repository.domain
+
+enum class VeilederBehandlingStatus {
+    IKKE_LEST,
+    LEST
+}

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/repository/util/DbUtil.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/repository/util/DbUtil.kt
@@ -1,0 +1,47 @@
+package no.nav.syfo.oppfolgingsplan.repository.util
+
+import org.apache.commons.text.StringEscapeUtils
+import org.owasp.html.HtmlPolicyBuilder
+import org.slf4j.LoggerFactory
+import org.springframework.jdbc.core.JdbcTemplate
+import java.sql.Timestamp
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+object DbUtil {
+
+    private val log = LoggerFactory.getLogger(DbUtil::class.java)
+    private val sanitizer = HtmlPolicyBuilder().toFactory()
+
+    fun nesteSekvensverdi(sekvensnavn: String, jdbcTemplate: JdbcTemplate): Long {
+        return jdbcTemplate.queryForObject("select $sekvensnavn.nextval from dual") { rs, _ -> rs.getLong(1) }!!
+    }
+
+    fun convert(timestamp: LocalDate?): Timestamp? {
+        return timestamp?.atStartOfDay()?.let { Timestamp.valueOf(it) }
+    }
+
+    fun convert(timestamp: LocalDateTime?): Timestamp? {
+        return timestamp?.let { Timestamp.valueOf(it) }
+    }
+
+    fun convert(timestamp: Timestamp?): LocalDateTime? {
+        return timestamp?.toLocalDateTime()
+    }
+
+    fun sanitizeUserInput(userinput: String?): String {
+        val sanitizedInput =
+            StringEscapeUtils.unescapeHtml4(sanitizer.sanitize(StringEscapeUtils.unescapeHtml4(userinput)))
+        if (sanitizedInput != userinput && userinput != null) {
+            log.warn(
+                "Dette er ikke en feil, men burde vært stoppet av regexen i frontend. " +
+                    "Finn ut hvorfor og evt. oppdater regex. \n" +
+                    "Det ble strippet vekk innhold slik at denne teksten: {} \n" +
+                    "ble til denne teksten: {}",
+                userinput,
+                sanitizedInput
+            )
+        }
+        return sanitizedInput
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/util/OppfolgingsplanUtil.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/util/OppfolgingsplanUtil.kt
@@ -1,0 +1,120 @@
+package no.nav.syfo.oppfolgingsplan.util
+
+import no.nav.syfo.oppfolgingsplan.domain.ArbeidsoppgaveDTO
+import no.nav.syfo.oppfolgingsplan.domain.GjennomfoeringDTO.KanGjennomfoeres.KAN
+import no.nav.syfo.oppfolgingsplan.domain.GjennomfoeringDTO.KanGjennomfoeres.KAN_IKKE
+import no.nav.syfo.oppfolgingsplan.domain.GjennomfoeringDTO.KanGjennomfoeres.TILRETTELEGGING
+import no.nav.syfo.oppfolgingsplan.domain.GodkjenningDTO
+import no.nav.syfo.oppfolgingsplan.domain.OppfolgingsplanDTO
+import no.nav.syfo.oppfolgingsplan.domain.TiltakDTO
+
+fun fjernEldsteGodkjenning(godkjenninger: List<GodkjenningDTO>): List<GodkjenningDTO> {
+    return if (godkjenninger.size <= 1) {
+        emptyList()
+    } else {
+        godkjenninger.sortedBy { it.godkjenningsTidspunkt }.drop(1)
+    }
+}
+
+fun finnIkkeTattStillingTilArbeidsoppgaver(arbeidsoppgaveListe: List<ArbeidsoppgaveDTO>): List<ArbeidsoppgaveDTO> {
+    return arbeidsoppgaveListe.filter { !it.erVurdertAvSykmeldt }
+}
+
+fun finnKanGjennomfoeresArbeidsoppgaver(arbeidsoppgaveListe: List<ArbeidsoppgaveDTO>): List<ArbeidsoppgaveDTO> {
+    return arbeidsoppgaveListe.filter { KAN.name == it.gjennomfoering?.gjennomfoeringStatus?.name }
+}
+
+fun finnKanIkkeGjennomfoeresArbeidsoppgaver(arbeidsoppgaveListe: List<ArbeidsoppgaveDTO>): List<ArbeidsoppgaveDTO> {
+    return arbeidsoppgaveListe.filter { KAN_IKKE.name == it.gjennomfoering?.gjennomfoeringStatus?.name }
+}
+
+fun finnKanGjennomfoeresMedTilretteleggingArbeidsoppgaver(arbeidsoppgaveListe: List<ArbeidsoppgaveDTO>): List<ArbeidsoppgaveDTO> {
+    return arbeidsoppgaveListe.filter { TILRETTELEGGING.name == it.gjennomfoering?.gjennomfoeringStatus?.name }
+}
+
+fun erGodkjentAvAnnenPart(oppfolgingsplan: OppfolgingsplanDTO, aktoerId: String): Boolean {
+    return if (erArbeidstakeren(oppfolgingsplan, aktoerId)) {
+        harArbeidsgiverGodkjentPlan(oppfolgingsplan)
+    } else {
+        harArbeidstakerGodkjentPlan(oppfolgingsplan)
+    }
+}
+
+fun annenPartHarGjortEndringerImellomtiden(oppfolgingsplan: OppfolgingsplanDTO, innloggetAktoerId: String): Boolean {
+    return if (erArbeidstakeren(oppfolgingsplan, innloggetAktoerId)) {
+        oppfolgingsplan.sistEndretArbeidsgiver != null &&
+            oppfolgingsplan.arbeidstaker.sistAksessert != null &&
+            oppfolgingsplan.arbeidstaker.sistAksessert.isBefore(
+                oppfolgingsplan.sistEndretArbeidsgiver
+            )
+    } else {
+        oppfolgingsplan.sistEndretSykmeldt != null &&
+            oppfolgingsplan.arbeidsgiver.sistAksessert != null &&
+            oppfolgingsplan.arbeidsgiver.sistAksessert.isBefore(
+                oppfolgingsplan.sistEndretSykmeldt
+            )
+    }
+}
+
+fun sisteGodkjenningAvAnnenPart(oppfolgingsplan: OppfolgingsplanDTO, innloggetAktoerId: String): GodkjenningDTO {
+    return if (erArbeidstakeren(oppfolgingsplan, innloggetAktoerId)) {
+        oppfolgingsplan.godkjenninger.stream()
+            .filter { godkjenning -> godkjenning.godkjentAvAktoerId == innloggetAktoerId }
+            .sorted { o1, o2 -> o2.godkjenningsTidspunkt!!.compareTo(o1.godkjenningsTidspunkt) }.findFirst().get()
+    } else {
+        oppfolgingsplan.godkjenninger.stream()
+            .filter { godkjenning -> godkjenning.godkjentAvAktoerId != innloggetAktoerId }
+            .sorted { o1, o2 -> o2.godkjenningsTidspunkt!!.compareTo(o1.godkjenningsTidspunkt) }.findFirst().get()
+    }
+}
+
+fun harArbeidsgiverGodkjentPlan(oppfolgingsplan: OppfolgingsplanDTO): Boolean {
+    return oppfolgingsplan.godkjenninger.any { godkjenning ->
+        !erArbeidstakeren(oppfolgingsplan, godkjenning.godkjentAvAktoerId) && godkjenning.godkjent
+    }
+}
+
+fun harArbeidstakerGodkjentPlan(oppfolgingsplan: OppfolgingsplanDTO): Boolean {
+    return oppfolgingsplan.godkjenninger.any { godkjenning ->
+        erArbeidstakeren(oppfolgingsplan, godkjenning.godkjentAvAktoerId) && godkjenning.godkjent
+    }
+}
+
+fun erArbeidstakeren(oppfolgingsplan: OppfolgingsplanDTO, aktoerId: String?): Boolean {
+    return aktoerId == oppfolgingsplan.arbeidstaker.aktoerId
+}
+
+fun erArbeidsgiveren(oppfolgingsplan: OppfolgingsplanDTO, aktoerId: String?): Boolean {
+    return !erArbeidstakeren(oppfolgingsplan, aktoerId)
+}
+
+fun isLoggedInpersonLeaderAndOwnLeader(
+    oppfolgingsplan: OppfolgingsplanDTO,
+    loggedInPersonFnr: String,
+    leaderFnr: String
+): Boolean {
+    return oppfolgingsplan.arbeidstaker.fnr == leaderFnr && loggedInPersonFnr == leaderFnr
+}
+
+fun eksisterendeTiltakHoererTilDialog(tiltakId: Long?, tiltakListe: List<TiltakDTO>): Boolean {
+    return tiltakId == null || tiltakListe.any { tiltak -> tiltak.id == tiltakId }
+}
+
+fun eksisterendeArbeidsoppgaveHoererTilDialog(
+    arbeidsoppgaveId: Long?,
+    arbeidsoppgaveListe: List<ArbeidsoppgaveDTO>
+): Boolean {
+    return arbeidsoppgaveId == null ||
+        arbeidsoppgaveListe.any { arbeidsoppgave -> arbeidsoppgave.id == arbeidsoppgaveId }
+}
+
+fun kanEndreElement(innloggetAktoerId: String, arbeidstakerAktoerId: String, opprettetAvAktoerId: String): Boolean {
+    if (opprettetAvAktoerId == innloggetAktoerId) {
+        return true
+    }
+    // Hvis tidligere nærmeste leder har opprettet elementet, skal ny nærmeste leder kunne endre det
+    if (innloggetAktoerId != arbeidstakerAktoerId && opprettetAvAktoerId != arbeidstakerAktoerId) {
+        return true
+    }
+    return false
+}

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/util/OppfolgingsplanUtil.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/util/OppfolgingsplanUtil.kt
@@ -28,7 +28,7 @@ fun finnKanIkkeGjennomfoeresArbeidsoppgaver(arbeidsoppgaveListe: List<Arbeidsopp
     return arbeidsoppgaveListe.filter { KAN_IKKE.name == it.gjennomfoering?.gjennomfoeringStatus?.name }
 }
 
-fun finnKanGjennomfoeresMedTilretteleggingArbeidsoppgaver(arbeidsoppgaveListe: List<ArbeidsoppgaveDTO>): List<ArbeidsoppgaveDTO> {
+fun finnKanGjennomfoeresMedTilrettelegging(arbeidsoppgaveListe: List<ArbeidsoppgaveDTO>): List<ArbeidsoppgaveDTO> {
     return arbeidsoppgaveListe.filter { TILRETTELEGGING.name == it.gjennomfoering?.gjennomfoeringStatus?.name }
 }
 
@@ -109,12 +109,14 @@ fun eksisterendeArbeidsoppgaveHoererTilDialog(
 }
 
 fun kanEndreElement(innloggetAktoerId: String, arbeidstakerAktoerId: String, opprettetAvAktoerId: String): Boolean {
-    if (opprettetAvAktoerId == innloggetAktoerId) {
-        return true
+    return when {
+        opprettetAvAktoerId == innloggetAktoerId -> {
+            true
+        }
+        // Hvis tidligere nærmeste leder har opprettet elementet, skal ny nærmeste leder kunne endre det
+        innloggetAktoerId != arbeidstakerAktoerId && opprettetAvAktoerId != arbeidstakerAktoerId -> {
+            true
+        }
+        else -> false
     }
-    // Hvis tidligere nærmeste leder har opprettet elementet, skal ny nærmeste leder kunne endre det
-    if (innloggetAktoerId != arbeidstakerAktoerId && opprettetAvAktoerId != arbeidstakerAktoerId) {
-        return true
-    }
-    return false
 }

--- a/src/main/kotlin/no/nav/syfo/util/RequestUtil.kt
+++ b/src/main/kotlin/no/nav/syfo/util/RequestUtil.kt
@@ -9,4 +9,3 @@ const val ORGNUMMER_HEADER = "orgnummer"
 const val NAV_PERSONIDENT_HEADER = "nav-personident"
 
 fun createCallId(): String = UUID.randomUUID().toString()
-

--- a/src/main/kotlin/no/nav/syfo/util/StringUtil.kt
+++ b/src/main/kotlin/no/nav/syfo/util/StringUtil.kt
@@ -9,5 +9,3 @@ fun fodselsnummerInvalid(fnr: String): Boolean = !fodselsnummerValid(fnr)
 fun String.lowerCapitalize(): String {
     return this.lowercase().replaceFirstChar { it.uppercase() }
 }
-
-

--- a/src/main/kotlin/no/nav/syfo/virksomhet/VirksomhetController.kt
+++ b/src/main/kotlin/no/nav/syfo/virksomhet/VirksomhetController.kt
@@ -2,11 +2,11 @@ package no.nav.syfo.virksomhet
 
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import no.nav.security.token.support.core.context.TokenValidationContextHolder
-import no.nav.syfo.auth.tokenx.TokenXUtil.TokenXIssuer.TOKENX
-import no.nav.syfo.ereg.EregClient
-import no.nav.syfo.domain.Virksomhet
 import no.nav.syfo.auth.tokenx.TokenXUtil
+import no.nav.syfo.auth.tokenx.TokenXUtil.TokenXIssuer.TOKENX
+import no.nav.syfo.domain.Virksomhet
 import no.nav.syfo.domain.Virksomhetsnummer
+import no.nav.syfo.ereg.EregClient
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
@@ -16,7 +16,6 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-
 
 @RestController
 @ProtectedWithClaims(issuer = TOKENX, claimMap = ["acr=Level4", "acr=idporten-loa-high"], combineWithOr = true)
@@ -52,5 +51,4 @@ class VirksomhetController(
     companion object {
         private val LOG = LoggerFactory.getLogger(VirksomhetController::class.java)
     }
-
 }

--- a/src/test/kotlin/no/nav/syfo/virksomhet/VirksomhetControllerTest.kt
+++ b/src/test/kotlin/no/nav/syfo/virksomhet/VirksomhetControllerTest.kt
@@ -10,8 +10,8 @@ import no.nav.security.token.support.core.jwt.JwtTokenClaims
 import no.nav.syfo.domain.Virksomhet
 import no.nav.syfo.ereg.EregClient
 import no.nav.syfo.testhelper.UserConstants.VIRKSOMHETSNUMMER
-import org.springframework.http.ResponseEntity
 import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
 
 class VirksomhetControllerTest : FunSpec({
 


### PR DESCRIPTION
Første PR for å flytte over selve oppfølgingsplan-funksjonaliteten.

Jeg var veldig usikker på hvordan best flytte over, da det er et stort "spider web" som er avhengig av hverandre for å kunne fungere.

Denne PR-en flytter OppfolgingsplanInternControllerV3fra Syfooppfolgingsplanservice til OppfolgingsplanInternControllerV1 i oppfolgingsplan-backend. Jeg har tatt med alle avhengigheter for å få koden til å kompilere, men har ikke tatt med oppretting av database osv i denne PRen.

Mye av den gamle koden var skrevet i java, alt er skrevet om til kotlin.
