### PR TITLE
chore: migrate hovmester auto-merge to consumer-owned verify

### DIFF
--- a/.github/workflows/hovmester-sync.yaml
+++ b/.github/workflows/hovmester-sync.yaml
@@ -1,15 +1,18 @@
-name: Copilot Config Sync
+name: Sync hovmester
 on:
   schedule:
     - cron: '0 5 * * *'
   workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   sync:
     uses: navikt/hovmester/.github/workflows/hovmester-sync.yml@main
     with:
       collections: "hovmester,backend"
+      pr_app_id: "2906300"
     secrets:
       APP_PRIVATE_KEY: ${{ secrets.AUTOMERGE_APP_PRIVATE_KEY }}
-    permissions:
-      contents: write
-      pull-requests: write

--- a/.github/workflows/hovmester-verify.yml
+++ b/.github/workflows/hovmester-verify.yml
@@ -1,0 +1,79 @@
+# Managed by team — do not sync from hovmester.
+name: Verify and merge hovmester sync
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  verify-hovmester-sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Verify file scope
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_REF: ${{ github.head_ref }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          EXPECTED_PR_AUTHOR: "teamesyfo-automerge[bot]"
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$HEAD_REF" != "hovmester-sync" ]] || [[ "$HEAD_REPO" != "$REPO" ]]; then
+            echo "Not a hovmester sync PR — skipping"
+            exit 0
+          fi
+
+          if [[ "$PR_AUTHOR" != "$EXPECTED_PR_AUTHOR" ]]; then
+            echo "::error::Unexpected PR author: $PR_AUTHOR"
+            echo "Expected PR author: $EXPECTED_PR_AUTHOR"
+            exit 1
+          fi
+
+          FILES=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/files" \
+            --paginate --jq '.[] | .filename, (.previous_filename // empty)')
+
+          if [ -z "$FILES" ]; then
+            echo "::warning::No files found — skipping (possible API issue)"
+            exit 1
+          fi
+
+          echo "Changed files:"
+          echo "$FILES"
+
+          while IFS= read -r file; do
+            [[ -z "$file" ]] && continue
+            case "$file" in
+              .github/agents/*|\
+              .github/instructions/*|\
+              .github/skills/*|\
+              .github/ISSUE_TEMPLATE/*|\
+              .github/PULL_REQUEST_TEMPLATE.md|\
+              .github/.hovmester-manifest.json|\
+              .github/.copilot-kitchen-manifest.json)
+                ;;
+              *)
+                echo "::error::File outside sync scope: $file"
+                echo "Only hovmester-managed paths are allowed in sync PRs"
+                exit 1
+                ;;
+            esac
+          done <<< "$FILES"
+
+          echo "✅ All files within hovmester sync scope"
+
+      - name: Approve and enable auto-merge
+        if: github.head_ref == 'hovmester-sync' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'teamesyfo-automerge[bot]'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr review "$PR_NUMBER" --approve --body "Auto-approved: file scope verified ✅"
+          gh pr merge "$PR_NUMBER" --auto --squash


### PR DESCRIPTION
## Beskrivelse

Hovmester-sync har fjernet innebygd auto-approve/merge. Ansvaret flyttes til en consumer-eid verify-workflow (`hovmester-verify.yml`).

### Endringer

1. **`hovmester-sync.yaml`**: Legg til `pr_app_id`, flytt permissions til top-level, oppdater navn
2. **`hovmester-verify.yml`** (ny): Verifiserer filscope + auto-approver + enabler auto-merge

### Manuelle steg etter merge

- [ ] Slå på **Allow auto-merge** i repo settings
- [ ] Slå på **Allow squash merging** i repo settings
- [ ] Slå på **Settings → Actions → General → Allow GitHub Actions to create and approve pull requests**
- [ ] Sett `verify-hovmester-sync` som **required status check** i branch protection (gjør dette *etter* merge)

Se [hovmester README — Auto-merge](https://github.com/navikt/hovmester#auto-merge-valgfritt).