### PR TITLE
fix(ci): remove duplicate REPO env key in hovmester-verify

### DIFF
--- a/.github/workflows/hovmester-verify.yml
+++ b/.github/workflows/hovmester-verify.yml
@@ -18,7 +18,6 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
           HEAD_REF: ${{ github.head_ref }}
           HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}


### PR DESCRIPTION
## Summary
- remove the duplicated REPO env entry from the Verify file scope step
- keep the required REPO env entry in the verify step and in the approve step
- restore a valid hovmester verify workflow so sync PRs can run

## Why
GitHub Actions rejected the workflow because the Verify file scope step defined the same REPO key twice in one env block. That prevented the verify workflow from starting at all, which blocked pending sync PRs like #197.