### PR TITLE
Upgrade tomcat-embedded-core to 11.0.22

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,6 +38,9 @@ val owaspVersion = "20240325.1"
 val apacheCommonsTextVersion = "1.15.0"
 val detektVersion = "1.23.8"
 val jedisVersion = "7.5.0"
+val tomcatVersion = "11.0.22"
+
+extra["tomcat.version"] = tomcatVersion
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter")


### PR DESCRIPTION
## Beskrivelse

Oppdaterer runtime dependency-overrides for å lukke Google Cloud CVE-funn for Tomcat og Netty uten å hoppe til større dependency-linjer.

## Endringer

- `build.gradle.kts`: oppgraderer `tomcat.version` fra `11.0.21` til `11.0.22`


## Issue

Ingen issue. Gjelder kritiske sårbarhetsfunn fra Google Cloud scanner.

## Sjekkliste

- [x] Koden kompilerer og linter uten feil (`./gradlew --no-daemon build`)
- [x] Endringene er testet med `dependencyInsight` for `tomcat-embed-core`
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)