### PR TITLE
test(wiremock): bruk dynamiske porter

### DIFF
--- a/src/test/kotlin/no/nav/syfo/aareg/AaregClientTest.kt
+++ b/src/test/kotlin/no/nav/syfo/aareg/AaregClientTest.kt
@@ -3,6 +3,7 @@ package no.nav.syfo.aareg
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import io.kotest.assertions.throwables.shouldThrowExactly
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
@@ -18,9 +19,7 @@ import no.nav.syfo.auth.azure.AzureAdTokenClient
 import no.nav.syfo.cache.ValkeyStore
 import no.nav.syfo.metric.Metrikk
 import no.nav.syfo.util.configuredJacksonMapper
-import org.springframework.test.util.ReflectionTestUtils
 
-const val AAREG_URL = "http://localhost:9000"
 const val AAREG_SCOPE = "scope"
 
 class AaregClientTest : FunSpec({
@@ -30,17 +29,21 @@ class AaregClientTest : FunSpec({
 
     val valkeyStore = mockk<ValkeyStore>(relaxed = true)
 
-    val aaregClient = AaregClient(metrikk, azureAdTokenClient, valkeyStore, AAREG_URL, AAREG_SCOPE)
-
-    val isAaregServer = WireMockServer(9000)
+    val isAaregServer = WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort()).also { it.start() }
+    val aaregClient = AaregClient(
+        metrikk = metrikk,
+        azureAdTokenClient = azureAdTokenClient,
+        valkeyStore = valkeyStore,
+        url = "http://localhost:${isAaregServer.port()}",
+        scope = AAREG_SCOPE,
+    )
 
     beforeTest {
-        isAaregServer.start()
-        ReflectionTestUtils.setField(aaregClient, "url", AAREG_URL)
-        every { azureAdTokenClient.getSystemToken("scope") } returns "token"
+        isAaregServer.resetAll()
+        every { azureAdTokenClient.getSystemToken(AAREG_SCOPE) } returns "token"
         every { valkeyStore.getListObject(any<String>(), Arbeidsforhold::class.java) } returns null
     }
-    afterTest {
+    afterSpec {
         isAaregServer.resetAll()
         isAaregServer.stop()
     }

--- a/src/test/kotlin/no/nav/syfo/kontaktinfo/KrrClientTest.kt
+++ b/src/test/kotlin/no/nav/syfo/kontaktinfo/KrrClientTest.kt
@@ -3,6 +3,7 @@ package no.nav.syfo.kontaktinfo
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
@@ -17,28 +18,29 @@ import no.nav.syfo.util.configuredJacksonMapper
 import org.springframework.http.HttpStatus
 import java.util.UUID
 
-const val BASE_URL = "http://localhost:9000"
 const val REST_PATH = "/rest/v1/personer"
 
 class KrrClientTest : FunSpec({
     val azureAdTokenConsumer = mockk<AzureAdTokenClient>()
     val metric = mockk<Metrikk>()
     val krrScope = "some-scope"
-    val krrUrl = "$BASE_URL$REST_PATH"
+    val krrServer = WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort()).also { it.start() }
+    val baseUrl = "http://localhost:${krrServer.port()}"
+    val krrUrl = "$baseUrl$REST_PATH"
     val valkeyStore = mockk<ValkeyStore>()
 
     val validFnr = "12345678910"
     val unknownFnr = "01987654321"
 
     val krrClient = KrrClient(azureAdTokenConsumer, metric, krrScope, krrUrl, valkeyStore)
-    val krrServer = WireMockServer(9000)
     beforeTest {
-        krrServer.start()
+        krrServer.resetAll()
         every { azureAdTokenConsumer.getSystemToken(krrScope) } returns UUID.randomUUID().toString()
         every { metric.countOutgoingReponses(KrrClient.METRIC_CALL_KRR, any()) } returns Unit
         every { valkeyStore.setObject(any(), any<DigitalKontaktinfo>(), any()) } returns Unit
     }
-    afterTest {
+    afterSpec {
+        krrServer.resetAll()
         krrServer.stop()
     }
 

--- a/src/test/kotlin/no/nav/syfo/narmesteleder/NarmesteLederClientTest.kt
+++ b/src/test/kotlin/no/nav/syfo/narmesteleder/NarmesteLederClientTest.kt
@@ -3,6 +3,7 @@ package no.nav.syfo.narmesteleder
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
@@ -18,7 +19,6 @@ import no.nav.syfo.util.configuredJacksonMapper
 import java.time.LocalDate
 import java.time.LocalDateTime
 
-const val BASE_URL = "http://localhost:9000"
 const val ANSATT_FNR = "12345678910"
 
 class NarmesteLederClientTest : FunSpec({
@@ -28,17 +28,18 @@ class NarmesteLederClientTest : FunSpec({
     val mockJwtTokenClaims = mockk<JwtTokenClaims>()
     val mockJwtToken = mockk<JwtToken>()
     val valkeyStore = mockk<ValkeyStore>(relaxed = true)
+    val isnarmestelederServer =
+        WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort()).also { it.start() }
     val narmesteLederClient = NarmesteLederClient(
-        baseUrl = BASE_URL,
+        baseUrl = "http://localhost:${isnarmestelederServer.port()}",
         targetApp = "hei",
         tokenDingsConsumer = tokenDingsConsumer,
         contextHolder = contextHolder,
         valkeyStore = valkeyStore,
     )
-    val isnarmestelederServer = WireMockServer(9000)
 
     beforeTest {
-        isnarmestelederServer.start()
+        isnarmestelederServer.resetAll()
         every { contextHolder.getTokenValidationContext() } returns mockTokenValidationContext
         every { mockTokenValidationContext.getClaims(TokenXUtil.TokenXIssuer.TOKENX) } returns mockJwtTokenClaims
         every { mockJwtTokenClaims.getStringClaim("pid") } returns ANSATT_FNR
@@ -50,7 +51,8 @@ class NarmesteLederClientTest : FunSpec({
         every { valkeyStore.getObject(any<String>(), NarmesteLederRelasjonDTO::class.java) } returns null
     }
 
-    afterTest {
+    afterSpec {
+        isnarmestelederServer.resetAll()
         isnarmestelederServer.stop()
     }
 


### PR DESCRIPTION
## Beskrivelse

Endrer WireMock-oppsettet i klienttestene slik at de bruker dynamiske porter i stedet for fast lokal port 9000. Dette unngår at testene krasjer lokalt når porten allerede er opptatt.

## Endringer

- `AaregClientTest`: bruker dynamisk WireMock-port i klientens base-URL
- `KrrClientTest`: bruker dynamisk WireMock-port i klientens URL
- `NarmesteLederClientTest`: bruker dynamisk WireMock-port i klientens base-URL

## Issue

Ingen issue.

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)

Verifisert med:

```bash
./gradlew --no-daemon test --tests 'no.nav.syfo.aareg.AaregClientTest' --tests 'no.nav.syfo.kontaktinfo.KrrClientTest' --tests 'no.nav.syfo.narmesteleder.NarmesteLederClientTest' --quiet\n```